### PR TITLE
support multi-threading upload for shock-client (pcreate)

### DIFF
--- a/shock-client/lib/lib.go
+++ b/shock-client/lib/lib.go
@@ -122,7 +122,7 @@ func (n *Node) createOrUpdate(opts Opts) (err error) {
 		case "part":
 			if opts.HasKey("part") && opts.HasKey("file") {
 				println(opts.Value("part"), opts.Value("file"))
-				form.AddParam(opts.Value("part"), opts.Value("file"))
+				form.AddFile(opts.Value("part"), opts.Value("file"))
 			} else {
 				return errors.New("missing partial upload parameter: part or file")
 			}

--- a/shock-client/util.go
+++ b/shock-client/util.go
@@ -62,3 +62,13 @@ func downloadChunk(n lib.Node, opts lib.Opts, filename string, offset int64, c c
 	}
 	c <- 1
 }
+
+func uploadChunk(n lib.Node, opts lib.Opts, filename string, c chan int) {
+	if err := n.Update(opts); err != nil {
+		fmt.Printf("Error updating %s: %s\n", n.Id, err.Error())
+	} else {
+		os.Remove(filename)
+	}
+
+	c <- 1
+}


### PR DESCRIPTION
syntax:

shock-client -full=<u> [-threads=<i, default 4>] pcreate

[creating a new node with full file uploading, uploading is conducted by multiple goroutines working on different splits of the file]
