### PR TITLE
Ignoring io.EOF error when trying to determine the format of a file for ...

### DIFF
--- a/shock-server/node/file/format/multi/multi.go
+++ b/shock-server/node/file/format/multi/multi.go
@@ -14,18 +14,16 @@ import (
 )
 
 //the order matters as it determines the order for checking format.
-var valid_format = [3]string{"sam", "fastq", "fasta"}
+var validators = map[string]*regexp.Regexp{
+	"fasta": fasta.Regex,
+	"fastq": fastq.Regex,
+	"sam":   sam.Regex,
+}
 
 var readers = map[string]func(f file.SectionReader) seq.ReadRewinder{
 	"fasta": fasta.NewReader,
 	"fastq": fastq.NewReader,
 	"sam":   sam.NewReader,
-}
-
-var validators = map[string]*regexp.Regexp{
-	"fasta": fasta.Regex,
-	"fastq": fastq.Regex,
-	"sam":   sam.Regex,
 }
 
 type Reader struct {
@@ -46,9 +44,10 @@ func (r *Reader) DetermineFormat() error {
 	if r.format != "" && r.r != nil {
 		return nil
 	}
+
 	reader := io.NewSectionReader(r.f, 0, 32768)
 	buf := make([]byte, 32768)
-	if _, err := reader.Read(buf); err != nil {
+	if _, err := reader.Read(buf); err != nil && err != io.EOF {
 		return err
 	}
 


### PR DESCRIPTION
...indexing because DetermineFormat() function tries to read the first 32kb of the file and this would cause an io.EOF error on files smaller than 32kb.
