### PR TITLE
If download_post is used to copy a node to another Shock server and "Aut...

### DIFF
--- a/shock-server/controller/node/single.go
+++ b/shock-server/controller/node/single.go
@@ -353,6 +353,10 @@ func (cr *NodeController) Read(id string, ctx context.Context) error {
 			"Content-Length": strconv.FormatInt(form.Length, 10),
 		}
 
+		if _, hasAuth := ctx.HttpRequest().Header["Authorization"]; hasAuth {
+			headers["Authorization"] = ctx.HttpRequest().Header.Get("Authorization")
+		}
+
 		if res, err := client.Do("POST", post_url, headers, form.Reader); err == nil {
 			if res.StatusCode == 200 {
 				n := clientLib.Node{}


### PR DESCRIPTION
...horization" is included in the header of the GET request, that Authorization header will now be passed onto the secondary Shock server to which the node is being copied.
