### PR TITLE
Added "type" to the node object that defines node type as basic, virtual...

### DIFF
--- a/shock-server/controller/node/index/index.go
+++ b/shock-server/controller/node/index/index.go
@@ -106,9 +106,14 @@ func IndexTypedRequest(ctx context.Context) {
 
 		if idxType == "bai" {
 			//bam index is created by the command-line tool samtools
+			if n.Type == "subset" {
+				responder.RespondWithError(ctx, http.StatusBadRequest, "Shock does not support bam index creation on subset nodes.")
+				return
+			}
+
 			if ext := n.FileExt(); ext == ".bam" {
 				if err := index.CreateBamIndex(n.FilePath()); err != nil {
-					responder.RespondWithError(ctx, http.StatusBadRequest, "Error while creating bam index.")
+					responder.RespondWithError(ctx, http.StatusInternalServerError, "Error while creating bam index.")
 					return
 				}
 				responder.RespondOK(ctx)
@@ -119,7 +124,9 @@ func IndexTypedRequest(ctx context.Context) {
 			}
 		}
 
+		subsetSize := int64(0)
 		count := int64(0)
+		indexFormat := ""
 		subsetName := ""
 		if idxType == "subset" {
 			// Utilizing the multipart form parser since we need to upload a file.
@@ -157,7 +164,7 @@ func IndexTypedRequest(ctx context.Context) {
 			f, _ := os.Open(subsetIndices.Path)
 			defer f.Close()
 			idxer := index.NewSubsetIndexer(f)
-			count, _, err = index.CreateSubsetIndex(&idxer, n.IndexPath()+"/"+newIndex+".idx", n.IndexPath()+"/"+parentIndex+".idx")
+			count, subsetSize, indexFormat, err = index.CreateSubsetIndex(&idxer, n.IndexPath()+"/"+newIndex+".idx", n.IndexPath()+"/"+parentIndex+".idx")
 			if err != nil {
 				logger.Error("err " + err.Error())
 				responder.RespondWithError(ctx, http.StatusBadRequest, err.Error())
@@ -188,7 +195,7 @@ func IndexTypedRequest(ctx context.Context) {
 			f, _ := os.Open(n.FilePath())
 			defer f.Close()
 			idxer := index.NewColumnIndexer(f)
-			count, err = index.CreateColumnIndex(&idxer, num, n.IndexPath()+"/"+idxType+".idx")
+			count, indexFormat, err = index.CreateColumnIndex(&idxer, num, n.IndexPath()+"/"+idxType+".idx")
 			if err != nil {
 				logger.Error("err " + err.Error())
 				responder.RespondWithError(ctx, http.StatusBadRequest, err.Error())
@@ -199,7 +206,7 @@ func IndexTypedRequest(ctx context.Context) {
 			f, _ := os.Open(n.FilePath())
 			defer f.Close()
 			idxer := newIndexer(f)
-			count, err = idxer.Create(n.IndexPath() + "/" + idxType + ".idx")
+			count, indexFormat, err = idxer.Create(n.IndexPath() + "/" + idxType + ".idx")
 			if err != nil {
 				logger.Error("err " + err.Error())
 				responder.RespondWithError(ctx, http.StatusBadRequest, err.Error())
@@ -216,6 +223,7 @@ func IndexTypedRequest(ctx context.Context) {
 			Type:        idxType,
 			TotalUnits:  count,
 			AvgUnitSize: n.File.Size / count,
+			Format:      indexFormat,
 		}
 
 		//if idxType == "chunkrecord" {
@@ -223,8 +231,8 @@ func IndexTypedRequest(ctx context.Context) {
 		//}
 
 		if idxType == "subset" {
-			idxInfo.AvgUnitSize = -1
 			idxType = subsetName
+			idxInfo.AvgUnitSize = subsetSize / count
 		}
 
 		if err := n.SetIndexInfo(idxType, idxInfo); err != nil {

--- a/shock-server/controller/node/update.go
+++ b/shock-server/controller/node/update.go
@@ -49,6 +49,20 @@ func (cr *NodeController) Replace(id string, ctx context.Context) error {
 		return responder.RespondWithError(ctx, http.StatusBadRequest, err_msg)
 	}
 
+	if _, hasCopyData := params["copy_data"]; hasCopyData {
+		_, err = node.Load(params["copy_data"], u.Uuid)
+		if err != nil {
+			return request.AuthError(err, ctx)
+		}
+	}
+
+	if _, hasParentNode := params["parent_node"]; hasParentNode {
+		_, err = node.Load(params["parent_node"], u.Uuid)
+		if err != nil {
+			return request.AuthError(err, ctx)
+		}
+	}
+
 	err = n.Update(params, files)
 	if err != nil {
 		err_msg := "err@node_Update: " + id + ": " + err.Error()

--- a/shock-server/node/file/index/bai.go
+++ b/shock-server/node/file/index/bai.go
@@ -13,7 +13,7 @@ func NewBaiIndexer(f *os.File) Indexer {
 	return &bai{}
 }
 
-func (i *bai) Create(string) (count int64, err error) {
+func (i *bai) Create(string) (count int64, format string, err error) {
 	return
 }
 

--- a/shock-server/node/file/index/chunkrecord.go
+++ b/shock-server/node/file/index/chunkrecord.go
@@ -28,7 +28,7 @@ func NewChunkRecordIndexer(f *os.File) Indexer {
 	}
 }
 
-func (i *chunkRecord) Create(file string) (count int64, err error) {
+func (i *chunkRecord) Create(file string) (count int64, format string, err error) {
 	tmpFilePath := fmt.Sprintf("%s/temp/%d%d.idx", conf.Conf["data-path"], rand.Int(), rand.Int())
 
 	f, err := os.Create(tmpFilePath)
@@ -37,6 +37,7 @@ func (i *chunkRecord) Create(file string) (count int64, err error) {
 	}
 	defer f.Close()
 
+	format = "array"
 	curr := int64(0)
 	count = 0
 	for {

--- a/shock-server/node/file/index/column.go
+++ b/shock-server/node/file/index/column.go
@@ -26,11 +26,11 @@ func NewColumnIndexer(f *os.File) column {
 	}
 }
 
-func (c *column) Create(string) (count int64, err error) {
+func (c *column) Create(string) (count int64, format string, err error) {
 	return
 }
 
-func CreateColumnIndex(c *column, column int, ofile string) (count int64, err error) {
+func CreateColumnIndex(c *column, column int, ofile string) (count int64, format string, err error) {
 	tmpFilePath := fmt.Sprintf("%s/temp/%d%d.idx", conf.Conf["data-path"], rand.Int(), rand.Int())
 
 	f, err := os.Create(tmpFilePath)
@@ -39,6 +39,7 @@ func CreateColumnIndex(c *column, column int, ofile string) (count int64, err er
 	}
 	defer f.Close()
 
+	format = "array"
 	curr := int64(0) // stores the offset position of the current index
 	count = 0        // stores the number of indexed positions and get returned
 	total_n := 0     // stores the number of bytes read for the current index record
@@ -64,7 +65,7 @@ func CreateColumnIndex(c *column, column int, ofile string) (count int64, err er
 		// split line by columns and test if column value has changed
 		slices := bytes.Split(buf, []byte("\t"))
 		if len(slices) < column-1 {
-			return 0, errors.New("Specified column does not exist for all lines in file.")
+			return 0, format, errors.New("Specified column does not exist for all lines in file.")
 		}
 
 		str := string(slices[column-1])

--- a/shock-server/node/file/index/index.go
+++ b/shock-server/node/file/index/index.go
@@ -21,7 +21,7 @@ var (
 )
 
 type Indexer interface {
-	Create(string) (int64, error)
+	Create(string) (int64, string, error)
 	Close() error
 }
 

--- a/shock-server/node/file/index/line.go
+++ b/shock-server/node/file/index/line.go
@@ -24,7 +24,7 @@ func NewLineIndexer(f *os.File) Indexer {
 	}
 }
 
-func (l *lineRecord) Create(file string) (count int64, err error) {
+func (l *lineRecord) Create(file string) (count int64, format string, err error) {
 	tmpFilePath := fmt.Sprintf("%s/temp/%d%d.idx", conf.Conf["data-path"], rand.Int(), rand.Int())
 
 	f, err := os.Create(tmpFilePath)
@@ -33,6 +33,7 @@ func (l *lineRecord) Create(file string) (count int64, err error) {
 	}
 	defer f.Close()
 
+	format = "array"
 	curr := int64(0)
 	count = 0
 	for {

--- a/shock-server/node/file/index/record.go
+++ b/shock-server/node/file/index/record.go
@@ -25,7 +25,7 @@ func NewRecordIndexer(f *os.File) Indexer {
 	}
 }
 
-func (i *record) Create(file string) (count int64, err error) {
+func (i *record) Create(file string) (count int64, format string, err error) {
 	tmpFilePath := fmt.Sprintf("%s/temp/%d%d.idx", conf.Conf["data-path"], rand.Int(), rand.Int())
 
 	f, err := os.Create(tmpFilePath)
@@ -34,6 +34,7 @@ func (i *record) Create(file string) (count int64, err error) {
 	}
 	defer f.Close()
 
+	format = "array"
 	curr := int64(0)
 	count = 0
 	for {

--- a/shock-server/node/file/index/size.go
+++ b/shock-server/node/file/index/size.go
@@ -10,7 +10,7 @@ func NewSizeIndexer(f *os.File) Indexer {
 	return &size{}
 }
 
-func (i *size) Create(file string) (count int64, err error) {
+func (i *size) Create(file string) (count int64, format string, err error) {
 	return
 }
 

--- a/shock-server/node/file/index/subset.go
+++ b/shock-server/node/file/index/subset.go
@@ -30,7 +30,7 @@ func (s *subset) Create(string) (count int64, err error) {
 	return
 }
 
-func CreateSubsetIndex(s *subset, ofile string, ifile string) (count int64, size int64, err error) {
+func CreateSubsetIndex(s *subset, ofile string, ifile string) (count int64, size int64, format string, err error) {
 	tmpFilePath := fmt.Sprintf("%s/temp/%d%d.idx", conf.Conf["data-path"], rand.Int(), rand.Int())
 
 	f, err := os.Create(tmpFilePath)
@@ -47,6 +47,7 @@ func CreateSubsetIndex(s *subset, ofile string, ifile string) (count int64, size
 
 	count = 0
 	size = 0
+	format = "array"
 	prev_int := int(0)
 	for {
 		buf, er := s.r.ReadLine()

--- a/shock-server/node/update.go
+++ b/shock-server/node/update.go
@@ -69,6 +69,7 @@ func (node *Node) Update(params map[string]string, files FormFiles) (err error) 
 		}
 		delete(files, "upload")
 	} else if isPartialUpload {
+		node.Type = "parts"
 		if params["parts"] == "unknown" {
 			if err = node.initParts("unknown"); err != nil {
 				return err
@@ -92,6 +93,7 @@ func (node *Node) Update(params map[string]string, files FormFiles) (err error) 
 			}
 		}
 	} else if isVirtualNode {
+		node.Type = "virtual"
 		if source, hasSource := params["source"]; hasSource {
 			ids := strings.Split(source, ",")
 			node.addVirtualParts(ids)
@@ -135,6 +137,7 @@ func (node *Node) Update(params map[string]string, files FormFiles) (err error) 
 		node.File.Size = n.File.Size
 		node.File.Checksum = n.File.Checksum
 		node.File.Format = n.File.Format
+		node.Type = "copy"
 
 		// Copy node indexes
 		if _, copyIndex := params["copy_indexes"]; copyIndex && (len(n.Indexes) > 0) {
@@ -198,8 +201,8 @@ func (node *Node) Update(params map[string]string, files FormFiles) (err error) 
 		node.File.Name = n.File.Name
 		node.File.Format = n.File.Format
 		node.Type = "subset"
-		node.Parent.Id = params["parent_node"]
-		node.Parent.IndexName = params["parent_index"]
+		node.Subset.Parent.Id = params["parent_node"]
+		node.Subset.Parent.IndexName = params["parent_index"]
 
 		if n.File.Path == "" {
 			node.File.Path = fmt.Sprintf("%s/%s.data", getPath(params["parent_node"]), params["parent_node"])
@@ -337,7 +340,7 @@ func (node *Node) Update(params map[string]string, files FormFiles) (err error) 
 func (node *Node) Save() (err error) {
 	node.UpdateVersion()
 	if len(node.Revisions) == 0 || node.Revisions[len(node.Revisions)-1].Version != node.Version {
-		n := Node{node.Id, node.Version, node.File, node.Attributes, node.Public, node.Indexes, node.Acl, node.VersionParts, node.Tags, nil, node.Linkages, node.CreatedOn, node.LastModified, node.Type, node.Parent}
+		n := Node{node.Id, node.Version, node.File, node.Attributes, node.Public, node.Indexes, node.Acl, node.VersionParts, node.Tags, nil, node.Linkages, node.CreatedOn, node.LastModified, node.Type, node.Subset}
 		node.Revisions = append(node.Revisions, n)
 	}
 	if node.CreatedOn.String() == "0001-01-01 00:00:00 +0000 UTC" {


### PR DESCRIPTION
..., copy, subset, or parts.  Also, added Subset structure to node object to define parent node and subset information.  Lastly, added format field to all indexes.  Currently everything defaults to type array, except for the "size" index which is dynamic.  Will soon be adding the "matrix" index type that will allow for the creation of nodes that are subsets of subset nodes of a different index type.
