### PR TITLE
Add clients/shock-go zero-dependency Go client library

### DIFF
--- a/clients/shock-go/acl.go
+++ b/clients/shock-go/acl.go
@@ -1,0 +1,61 @@
+package shock
+
+import (
+	"context"
+	"net/url"
+)
+
+// GetAcl retrieves the ACL for a node.
+func (c *Client) GetAcl(ctx context.Context, nodeID string) (*DisplayAcl, error) {
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "GET", "/node/"+nodeID+"/acl", nil, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// PutAcl adds users to an ACL type on a node.
+func (c *Client) PutAcl(ctx context.Context, nodeID, aclType, users string) (*DisplayAcl, error) {
+	query := url.Values{}
+	if users != "" {
+		query.Set("users", users)
+	}
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "PUT", "/node/"+nodeID+"/acl/"+aclType, query, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// DeleteAcl removes users from an ACL type on a node.
+func (c *Client) DeleteAcl(ctx context.Context, nodeID, aclType, users string) (*DisplayAcl, error) {
+	query := url.Values{}
+	if users != "" {
+		query.Set("users", users)
+	}
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "DELETE", "/node/"+nodeID+"/acl/"+aclType, query, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// MakePublic sets a node's read ACL to public.
+func (c *Client) MakePublic(ctx context.Context, nodeID string) (*DisplayAcl, error) {
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "PUT", "/node/"+nodeID+"/acl/public_read", nil, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// ChownNode changes the owner of a node.
+func (c *Client) ChownNode(ctx context.Context, nodeID, user string) (*DisplayAcl, error) {
+	query := url.Values{}
+	query.Set("users", user)
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "PUT", "/node/"+nodeID+"/acl/owner", query, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}

--- a/clients/shock-go/client.go
+++ b/clients/shock-go/client.go
@@ -1,0 +1,66 @@
+package shock
+
+import (
+	"net/http"
+	"time"
+)
+
+// Client is a Shock API client.
+type Client struct {
+	baseURL    string
+	token      string
+	authType   string
+	httpClient *http.Client
+	debug      bool
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// New creates a new Shock client for the given base URL.
+func New(baseURL string, opts ...Option) *Client {
+	c := &Client{
+		baseURL:  baseURL,
+		authType: "OAuth",
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// WithToken sets the authentication token.
+func WithToken(token string) Option {
+	return func(c *Client) {
+		c.token = token
+	}
+}
+
+// WithAuthType sets the authorization type (e.g. "mgrast", "OAuth").
+func WithAuthType(authType string) Option {
+	return func(c *Client) {
+		c.authType = authType
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = hc
+	}
+}
+
+// WithDebug enables debug logging to stderr.
+func WithDebug(debug bool) Option {
+	return func(c *Client) {
+		c.debug = debug
+	}
+}
+
+// SetToken updates the authentication token.
+func (c *Client) SetToken(token string) {
+	c.token = token
+}

--- a/clients/shock-go/download.go
+++ b/clients/shock-go/download.go
@@ -127,14 +127,7 @@ func (c *Client) DownloadToFile(ctx context.Context, nodeID, filepath string, op
 		var src io.Reader = body
 		if cfg.computeMD5 {
 			// MD5 on compressed stream, then decompress
-			pReader, pWriter := io.Pipe()
-			defer pReader.Close()
-			dst := io.MultiWriter(pWriter, md5h)
-			go func() {
-				io.Copy(dst, body)
-				pWriter.Close()
-			}()
-			src = pReader
+			src = io.TeeReader(body, md5h)
 		}
 		gr, gerr := gzip.NewReader(src)
 		if gerr != nil {

--- a/clients/shock-go/download.go
+++ b/clients/shock-go/download.go
@@ -1,0 +1,182 @@
+package shock
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+)
+
+type downloadConfig struct {
+	uncompress string
+	computeMD5 bool
+}
+
+// DownloadOption configures a DownloadToFile call.
+type DownloadOption func(*downloadConfig)
+
+// WithUncompress sets the decompression method for downloads (e.g. "gzip").
+func WithUncompress(method string) DownloadOption {
+	return func(cfg *downloadConfig) {
+		cfg.uncompress = method
+	}
+}
+
+// WithComputeMD5 enables MD5 checksum computation during download.
+func WithComputeMD5() DownloadOption {
+	return func(cfg *downloadConfig) {
+		cfg.computeMD5 = true
+	}
+}
+
+// Download streams a node's file data. The caller must close the returned ReadCloser.
+func (c *Client) Download(ctx context.Context, nodeID string) (io.ReadCloser, error) {
+	query := url.Values{"download": {""}}
+	u := c.buildURL("/node/"+nodeID, query)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	c.debugf("GET %s (download)", u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode == http.StatusOK {
+		return res.Body, nil
+	}
+
+	// Error response — parse JSON envelope
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	var envelope struct {
+		Error []string `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && len(envelope.Error) > 0 {
+		return nil, &APIError{StatusCode: res.StatusCode, Errors: envelope.Error}
+	}
+	return nil, &APIError{StatusCode: res.StatusCode, Errors: []string{string(body)}}
+}
+
+// DownloadRange streams a byte range from a node's file.
+func (c *Client) DownloadRange(ctx context.Context, nodeID string, seek, length int64) (io.ReadCloser, error) {
+	query := url.Values{
+		"download": {""},
+		"seek":     {strconv.FormatInt(seek, 10)},
+		"length":   {strconv.FormatInt(length, 10)},
+	}
+	u := c.buildURL("/node/"+nodeID, query)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode == http.StatusOK {
+		return res.Body, nil
+	}
+
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	var envelope struct {
+		Error []string `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && len(envelope.Error) > 0 {
+		return nil, &APIError{StatusCode: res.StatusCode, Errors: envelope.Error}
+	}
+	return nil, &APIError{StatusCode: res.StatusCode, Errors: []string{string(body)}}
+}
+
+// DownloadToFile downloads a node's file to a local path, optionally decompressing and computing MD5.
+func (c *Client) DownloadToFile(ctx context.Context, nodeID, filepath string, opts ...DownloadOption) (int64, string, error) {
+	cfg := &downloadConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	body, err := c.Download(ctx, nodeID)
+	if err != nil {
+		return 0, "", err
+	}
+	defer body.Close()
+
+	localFile, err := os.Create(filepath)
+	if err != nil {
+		return 0, "", err
+	}
+	defer localFile.Close()
+
+	md5h := md5.New()
+	var size int64
+
+	if cfg.uncompress == "gzip" {
+		var src io.Reader = body
+		if cfg.computeMD5 {
+			// MD5 on compressed stream, then decompress
+			pReader, pWriter := io.Pipe()
+			defer pReader.Close()
+			dst := io.MultiWriter(pWriter, md5h)
+			go func() {
+				io.Copy(dst, body)
+				pWriter.Close()
+			}()
+			src = pReader
+		}
+		gr, gerr := gzip.NewReader(src)
+		if gerr != nil {
+			return 0, "", gerr
+		}
+		defer gr.Close()
+		size, err = io.Copy(localFile, gr)
+		if err != nil {
+			return 0, "", err
+		}
+	} else {
+		var dst io.Writer
+		if cfg.computeMD5 {
+			dst = io.MultiWriter(localFile, md5h)
+		} else {
+			dst = localFile
+		}
+		size, err = io.Copy(dst, body)
+		if err != nil {
+			return 0, "", err
+		}
+	}
+
+	var md5sum string
+	if cfg.computeMD5 {
+		md5sum = fmt.Sprintf("%x", md5h.Sum(nil))
+	}
+	return size, md5sum, nil
+}
+
+// GetDownloadURL gets a pre-authenticated download URL for a node.
+func (c *Client) GetDownloadURL(ctx context.Context, nodeID string) (*PreAuthResponse, error) {
+	query := url.Values{"download_url": {""}}
+	var resp PreAuthResponse
+	if err := c.doRequest(ctx, "GET", "/node/"+nodeID, query, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DownloadURL returns the direct download URL for a node (no pre-auth).
+func (c *Client) DownloadURL(nodeID string) string {
+	query := url.Values{"download": {""}}
+	return c.buildURL("/node/"+nodeID, query)
+}

--- a/clients/shock-go/errors.go
+++ b/clients/shock-go/errors.go
@@ -1,0 +1,19 @@
+package shock
+
+import (
+	"fmt"
+	"strings"
+)
+
+// APIError represents an error returned by the Shock API.
+type APIError struct {
+	StatusCode int
+	Errors     []string
+}
+
+func (e *APIError) Error() string {
+	if len(e.Errors) > 0 {
+		return fmt.Sprintf("shock API error (status %d): %s", e.StatusCode, strings.Join(e.Errors, "; "))
+	}
+	return fmt.Sprintf("shock API error (status %d)", e.StatusCode)
+}

--- a/clients/shock-go/go.mod
+++ b/clients/shock-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/MG-RAST/Shock/clients/shock-go
+
+go 1.22

--- a/clients/shock-go/helpers.go
+++ b/clients/shock-go/helpers.go
@@ -1,0 +1,198 @@
+package shock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+// doRequest performs a JSON request with no body and parses the envelope response.
+func (c *Client) doRequest(ctx context.Context, method, path string, query url.Values, result interface{}) error {
+	u := c.buildURL(path, query)
+	req, err := http.NewRequestWithContext(ctx, method, u, nil)
+	if err != nil {
+		return err
+	}
+	c.setAuth(req)
+	c.debugf("%s %s", method, u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return c.checkErrors(body, res.StatusCode, result)
+}
+
+// doJSON sends a JSON body request and parses the envelope response.
+func (c *Client) doJSON(ctx context.Context, method, path string, payload interface{}, result interface{}) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	u := c.buildURL(path, nil)
+	req, err := http.NewRequestWithContext(ctx, method, u, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setAuth(req)
+	c.debugf("%s %s (json body)", method, u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return c.checkErrors(body, res.StatusCode, result)
+}
+
+// doMultipart builds a multipart form and sends it. Returns raw response body.
+func (c *Client) doMultipart(ctx context.Context, method, urlPath string, cfg *createConfig) ([]byte, error) {
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+
+	// Write form in a goroutine to stream data without buffering
+	errCh := make(chan error, 1)
+	go func() {
+		var writeErr error
+		defer func() {
+			// Close writer first to finalize the multipart boundary
+			writer.Close()
+			if writeErr != nil {
+				pw.CloseWithError(writeErr)
+			} else {
+				pw.Close()
+			}
+			errCh <- writeErr
+		}()
+
+		// Write string params
+		for k, v := range cfg.params {
+			if err := writer.WriteField(k, v); err != nil {
+				writeErr = err
+				return
+			}
+		}
+
+		// Write file fields
+		for _, f := range cfg.files {
+			part, err := writer.CreateFormFile(f.fieldName, f.filename)
+			if err != nil {
+				writeErr = err
+				return
+			}
+			if f.reader != nil {
+				if _, err := io.Copy(part, f.reader); err != nil {
+					writeErr = err
+					return
+				}
+			} else if f.path != "" {
+				fh, err := os.Open(f.path)
+				if err != nil {
+					writeErr = err
+					return
+				}
+				_, err = io.Copy(part, fh)
+				fh.Close()
+				if err != nil {
+					writeErr = err
+					return
+				}
+			}
+		}
+	}()
+
+	u := c.buildURL(urlPath, nil)
+	req, err := http.NewRequestWithContext(ctx, method, u, pr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	c.setAuth(req)
+	c.debugf("%s %s (multipart)", method, u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		// Also check goroutine error
+		if wErr := <-errCh; wErr != nil {
+			return nil, fmt.Errorf("multipart write error: %w; http error: %w", wErr, err)
+		}
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	// Wait for goroutine to finish
+	<-errCh
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// checkErrors parses the envelope response and extracts .Data into result.
+func (c *Client) checkErrors(body []byte, statusCode int, result interface{}) error {
+	var envelope struct {
+		Status int             `json:"status"`
+		Data   json.RawMessage `json:"data"`
+		Error  []string        `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return &APIError{StatusCode: statusCode, Errors: []string{string(body)}}
+	}
+	if len(envelope.Error) > 0 {
+		return &APIError{StatusCode: envelope.Status, Errors: envelope.Error}
+	}
+	if result != nil && len(envelope.Data) > 0 {
+		return json.Unmarshal(envelope.Data, result)
+	}
+	return nil
+}
+
+// setAuth adds the Authorization header if a token is set.
+func (c *Client) setAuth(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Authorization", c.authType+" "+c.token)
+	}
+}
+
+// buildURL constructs a full URL from base + path + query params.
+func (c *Client) buildURL(path string, query url.Values) string {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		// Fallback: concatenate directly
+		s := c.baseURL + path
+		if query != nil && len(query) > 0 {
+			s += "?" + query.Encode()
+		}
+		return s
+	}
+	u.Path = path
+	if query != nil && len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
+}
+
+// debugf prints debug output to stderr when debug mode is enabled.
+func (c *Client) debugf(format string, args ...interface{}) {
+	if c.debug {
+		fmt.Fprintf(os.Stderr, "[shock-client] "+format+"\n", args...)
+	}
+}

--- a/clients/shock-go/helpers.go
+++ b/clients/shock-go/helpers.go
@@ -128,10 +128,9 @@ func (c *Client) doMultipart(ctx context.Context, method, urlPath string, cfg *c
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		// Also check goroutine error
-		if wErr := <-errCh; wErr != nil {
-			return nil, fmt.Errorf("multipart write error: %w; http error: %w", wErr, err)
-		}
+		// Close the pipe reader to unblock the writer goroutine
+		pr.Close()
+		<-errCh
 		return nil, err
 	}
 	defer res.Body.Close()

--- a/clients/shock-go/index.go
+++ b/clients/shock-go/index.go
@@ -1,0 +1,30 @@
+package shock
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+)
+
+// PutIndex creates or rebuilds an index on a node.
+func (c *Client) PutIndex(ctx context.Context, nodeID, indexName string) error {
+	if indexName == "" {
+		return nil
+	}
+	return c.doRequest(ctx, "PUT", "/node/"+nodeID+"/index/"+indexName, nil, nil)
+}
+
+// PutIndexQuery creates or rebuilds an index with options.
+func (c *Client) PutIndexQuery(ctx context.Context, nodeID, indexName string, force bool, column int) error {
+	if indexName == "" {
+		return nil
+	}
+	query := url.Values{}
+	if force {
+		query.Set("force_rebuild", "1")
+	}
+	if column > 0 {
+		query.Set("number", strconv.Itoa(column))
+	}
+	return c.doRequest(ctx, "PUT", "/node/"+nodeID+"/index/"+indexName, query, nil)
+}

--- a/clients/shock-go/location.go
+++ b/clients/shock-go/location.go
@@ -1,0 +1,35 @@
+package shock
+
+import "context"
+
+// GetLocations retrieves storage locations for a node.
+func (c *Client) GetLocations(ctx context.Context, nodeID string) ([]Location, error) {
+	var locs []Location
+	if err := c.doRequest(ctx, "GET", "/node/"+nodeID+"/locations/", nil, &locs); err != nil {
+		return nil, err
+	}
+	return locs, nil
+}
+
+// AddLocation adds a storage location to a node.
+func (c *Client) AddLocation(ctx context.Context, nodeID string, loc Location) ([]Location, error) {
+	var locs []Location
+	if err := c.doJSON(ctx, "POST", "/node/"+nodeID+"/locations/", loc, &locs); err != nil {
+		return nil, err
+	}
+	return locs, nil
+}
+
+// DeleteLocation removes a storage location from a node.
+func (c *Client) DeleteLocation(ctx context.Context, nodeID, locationID string) ([]Location, error) {
+	var locs []Location
+	if err := c.doRequest(ctx, "DELETE", "/node/"+nodeID+"/locations/"+locationID, nil, &locs); err != nil {
+		return nil, err
+	}
+	return locs, nil
+}
+
+// DeleteAllLocations removes all storage locations from a node.
+func (c *Client) DeleteAllLocations(ctx context.Context, nodeID string) error {
+	return c.doRequest(ctx, "DELETE", "/node/"+nodeID+"/locations/", nil, nil)
+}

--- a/clients/shock-go/md5.go
+++ b/clients/shock-go/md5.go
@@ -64,7 +64,7 @@ func (c *Client) PostFileLazy(ctx context.Context, filepath, filename string) (s
 
 		baseName := path.Base(filepath)
 		md5sumFileContent := md5sum + " " + baseName
-		if writeErr := os.WriteFile(md5Filename, []byte(md5sumFileContent), 0644); writeErr != nil {
+		if writeErr := os.WriteFile(md5Filename, []byte(md5sumFileContent), 0600); writeErr != nil {
 			c.debugf("PostFileLazy: could not write md5sum: %s, continuing", writeErr.Error())
 		}
 	} else {

--- a/clients/shock-go/md5.go
+++ b/clients/shock-go/md5.go
@@ -1,0 +1,107 @@
+package shock
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+	"path"
+)
+
+// GetMD5FromFile computes the MD5 checksum of a file.
+func GetMD5FromFile(filepath string) (string, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// GetNodeByMD5 searches for an existing node with the given MD5 checksum.
+// Returns the node ID, whether a match was found, and any error.
+func (c *Client) GetNodeByMD5(ctx context.Context, md5sum string) (string, bool, error) {
+	filters := map[string]string{
+		"file.checksum.md5": md5sum,
+		"type":              "basic",
+	}
+	sr, err := c.QueryFull(ctx, filters)
+	if err != nil {
+		return "", false, err
+	}
+	if len(sr.Nodes) > 0 {
+		c.debugf("GetNodeByMD5: found existing node: %s", sr.Nodes[0].Id)
+		return sr.Nodes[0].Id, true, nil
+	}
+	c.debugf("GetNodeByMD5: file not found in Shock")
+	return "", false, nil
+}
+
+// PostFileLazy creates a node with a file, but first checks if a node with
+// the same MD5 already exists. If so, returns the existing node ID.
+// It caches MD5 checksums in .md5 files alongside the source file.
+func (c *Client) PostFileLazy(ctx context.Context, filepath, filename string) (string, error) {
+	md5Filename := filepath + ".md5"
+	var md5sum string
+
+	c.debugf("PostFileLazy: filepath=%s (md5Filename=%s)", filepath, md5Filename)
+
+	if _, err := os.Stat(md5Filename); err != nil {
+		// .md5 file not found, calculate
+		c.debugf("PostFileLazy: calculating md5sum...")
+		var calcErr error
+		md5sum, calcErr = GetMD5FromFile(filepath)
+		if calcErr != nil {
+			return "", fmt.Errorf("GetMD5FromFile: %w", calcErr)
+		}
+		c.debugf("PostFileLazy: calculated md5sum: %s", md5sum)
+
+		baseName := path.Base(filepath)
+		md5sumFileContent := md5sum + " " + baseName
+		if writeErr := os.WriteFile(md5Filename, []byte(md5sumFileContent), 0644); writeErr != nil {
+			c.debugf("PostFileLazy: could not write md5sum: %s, continuing", writeErr.Error())
+		}
+	} else {
+		// .md5 file exists
+		md5sumBytes, readErr := os.ReadFile(md5Filename)
+		if readErr != nil {
+			return "", fmt.Errorf("could not read md5sum file: %w", readErr)
+		}
+		if len(md5sumBytes) >= 32 {
+			md5sum = string(md5sumBytes[0:32])
+		}
+		c.debugf("PostFileLazy: got cached md5sum: %s", md5sum)
+	}
+
+	if md5sum != "" {
+		nodeid, ok, err := c.GetNodeByMD5(ctx, md5sum)
+		if err != nil {
+			c.debugf("PostFileLazy: GetNodeByMD5 error: %s", err.Error())
+		} else if ok {
+			return nodeid, nil
+		}
+	}
+
+	// File not found in Shock, upload it
+	var opts []CreateOption
+	if filepath != "" {
+		opts = append(opts, WithFilePath(filepath))
+	}
+	if filename != "" {
+		opts = append(opts, WithFileName(filename))
+	}
+	node, err := c.CreateNode(ctx, opts...)
+	if err != nil {
+		return "", err
+	}
+	if node != nil {
+		return node.Id, nil
+	}
+	return "", nil
+}

--- a/clients/shock-go/node.go
+++ b/clients/shock-go/node.go
@@ -1,0 +1,205 @@
+package shock
+
+import (
+	"context"
+	"net/url"
+)
+
+// GetNode retrieves a node by ID.
+func (c *Client) GetNode(ctx context.Context, id string) (*Node, error) {
+	var node Node
+	if err := c.doRequest(ctx, "GET", "/node/"+id, nil, &node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+// DeleteNode deletes a node by ID.
+func (c *Client) DeleteNode(ctx context.Context, id string) error {
+	return c.doRequest(ctx, "DELETE", "/node/"+id, nil, nil)
+}
+
+// CreateNode creates a new node with the given options.
+func (c *Client) CreateNode(ctx context.Context, opts ...CreateOption) (*Node, error) {
+	cfg := buildConfig(opts)
+	applyCompression(cfg)
+
+	body, err := c.doMultipart(ctx, "POST", "/node", cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var node Node
+	if err := c.checkErrors(body, 200, &node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+// UpdateNode updates an existing node with the given options.
+func (c *Client) UpdateNode(ctx context.Context, id string, opts ...CreateOption) (*Node, error) {
+	cfg := buildConfig(opts)
+	applyCompression(cfg)
+
+	body, err := c.doMultipart(ctx, "PUT", "/node/"+id, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var node Node
+	if err := c.checkErrors(body, 200, &node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+// UpdateAttributes updates the attributes of an existing node.
+func (c *Client) UpdateAttributes(ctx context.Context, id string, attrFile string, nodeattr map[string]interface{}) error {
+	var opts []CreateOption
+	if attrFile != "" {
+		opts = append(opts, WithAttributesFile(attrFile))
+	}
+	if len(nodeattr) > 0 {
+		opts = append(opts, WithAttributes(nodeattr))
+	}
+	_, err := c.UpdateNode(ctx, id, opts...)
+	return err
+}
+
+// PostFileWithAttributes creates a node with a file and attributes.
+func (c *Client) PostFileWithAttributes(ctx context.Context, filepath, filename string, nodeattr map[string]interface{}) (*Node, error) {
+	opts := []CreateOption{WithFilePath(filepath)}
+	if filename != "" {
+		opts = append(opts, WithFileName(filename))
+	}
+	if len(nodeattr) > 0 {
+		opts = append(opts, WithAttributes(nodeattr))
+	}
+	return c.CreateNode(ctx, opts...)
+}
+
+// PutOrPostFile provides backward compatibility with the old client.
+// If nodeid is empty, creates a new node (POST); otherwise updates (PUT).
+func (c *Client) PutOrPostFile(ctx context.Context, filename, nodeid string, rank int, attrfile, ntype string, formopts map[string]string, nodeattr map[string]interface{}) (string, error) {
+	var opts []CreateOption
+
+	// Attributes
+	if attrfile != "" && rank < 2 {
+		opts = append(opts, WithAttributesFile(attrfile))
+	}
+	if len(nodeattr) > 0 {
+		opts = append(opts, WithAttributes(nodeattr))
+	}
+
+	// Form options
+	if v, ok := formopts["file_name"]; ok {
+		opts = append(opts, WithFileName(v))
+	}
+	if v, ok := formopts["expiration"]; ok {
+		opts = append(opts, WithExpiration(v))
+	}
+	if _, ok := formopts["remove_expiration"]; ok {
+		opts = append(opts, WithRemoveExpiration())
+	}
+
+	compression := formopts["compression"]
+
+	if rank > 0 && filename == "" {
+		// Parts node initialization
+		opts = append(opts, WithParts(rank))
+		if compression != "" {
+			opts = append(opts, WithPartsCompression(compression))
+		}
+		// Also handle file_name from parts option
+		if v, ok := formopts["parts"]; ok {
+			n, _ := url.QueryUnescape(v)
+			_ = n
+		}
+	} else if rank > 0 && filename != "" {
+		// Part upload
+		opts = append(opts, WithPartFile(rank, filename))
+	} else {
+		// Handle different node types
+		switch ntype {
+		case "virtual":
+			if v, ok := formopts["virtual_file"]; ok {
+				opts = append(opts, WithVirtualParts(splitComma(v)))
+			}
+		case "remote":
+			if v, ok := formopts["remote_url"]; ok {
+				opts = append(opts, WithRemoteURL(v))
+			}
+		case "copy":
+			if v, ok := formopts["parent_node"]; ok {
+				opts = append(opts, WithCopyData(v))
+			}
+			if _, ok := formopts["copy_indexes"]; ok {
+				opts = append(opts, WithCopyIndexes())
+			}
+			if _, ok := formopts["copy_attributes"]; ok {
+				opts = append(opts, WithCopyAttributes())
+			}
+		case "parts":
+			if v, ok := formopts["parts"]; ok {
+				opts = append(opts, withPartsString(v))
+			}
+			if compression != "" {
+				opts = append(opts, WithPartsCompression(compression))
+			}
+		default:
+			if filename != "" {
+				opts = append(opts, WithFilePath(filename))
+				if compression != "" {
+					opts = append(opts, WithCompression(compression))
+				}
+			}
+		}
+	}
+
+	var node *Node
+	var err error
+	if nodeid != "" {
+		node, err = c.UpdateNode(ctx, nodeid, opts...)
+	} else {
+		node, err = c.CreateNode(ctx, opts...)
+	}
+	if err != nil {
+		return "", err
+	}
+	if node != nil {
+		return node.Id, nil
+	}
+	return "", nil
+}
+
+func splitComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := make([]string, 0)
+	for _, p := range splitStr(s, ',') {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+func splitStr(s string, sep byte) []string {
+	var result []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	result = append(result, s[start:])
+	return result
+}
+
+func withPartsString(s string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["parts"] = s
+	}
+}

--- a/clients/shock-go/node.go
+++ b/clients/shock-go/node.go
@@ -1,9 +1,6 @@
 package shock
 
-import (
-	"context"
-	"net/url"
-)
+import "context"
 
 // GetNode retrieves a node by ID.
 func (c *Client) GetNode(ctx context.Context, id string) (*Node, error) {
@@ -109,11 +106,6 @@ func (c *Client) PutOrPostFile(ctx context.Context, filename, nodeid string, ran
 		opts = append(opts, WithParts(rank))
 		if compression != "" {
 			opts = append(opts, WithPartsCompression(compression))
-		}
-		// Also handle file_name from parts option
-		if v, ok := formopts["parts"]; ok {
-			n, _ := url.QueryUnescape(v)
-			_ = n
 		}
 	} else if rank > 0 && filename != "" {
 		// Part upload

--- a/clients/shock-go/query.go
+++ b/clients/shock-go/query.go
@@ -97,12 +97,6 @@ func itoa(n int) string {
 
 func (c *Client) nodeQuery(ctx context.Context, query url.Values) (*QueryResult, error) {
 	var resp nodesResponse
-	if err := c.doRequest(ctx, "GET", "/node", query, nil); err != nil {
-		// doRequest with nil result won't unmarshal data, so we need raw approach
-		return nil, err
-	}
-	// We need to get the full paginated response, not just the data field.
-	// Use a raw request instead.
 	u := c.buildURL("/node", query)
 	req, err := c.rawRequest(ctx, "GET", u)
 	if err != nil {

--- a/clients/shock-go/query.go
+++ b/clients/shock-go/query.go
@@ -1,0 +1,185 @@
+package shock
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// QueryResult holds the result of a node query.
+type QueryResult struct {
+	Nodes      []Node
+	Limit      int
+	Offset     int
+	TotalCount int
+}
+
+type queryConfig struct {
+	limit     int
+	offset    int
+	order     string
+	direction string
+}
+
+// QueryOption configures a Query call.
+type QueryOption func(*queryConfig)
+
+// WithLimit sets the maximum number of results.
+func WithLimit(n int) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.limit = n
+	}
+}
+
+// WithOffset sets the starting offset.
+func WithOffset(n int) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.offset = n
+	}
+}
+
+// WithOrder sets the field to sort by.
+func WithOrder(field string) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.order = field
+	}
+}
+
+// WithDirection sets the sort direction ("asc" or "desc").
+func WithDirection(dir string) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.direction = dir
+	}
+}
+
+func buildQueryValues(filters map[string]string, qcfg *queryConfig, queryType string) url.Values {
+	query := url.Values{}
+	query.Set(queryType, "")
+	for k, v := range filters {
+		query.Set(k, v)
+	}
+	if qcfg.limit > 0 {
+		query.Set("limit", intToStr(qcfg.limit))
+	}
+	if qcfg.offset > 0 {
+		query.Set("offset", intToStr(qcfg.offset))
+	}
+	if qcfg.order != "" {
+		query.Set("order", qcfg.order)
+	}
+	if qcfg.direction != "" {
+		query.Set("direction", qcfg.direction)
+	}
+	return query
+}
+
+func intToStr(n int) string {
+	return url.QueryEscape(json.Number(itoa(n)).String())
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	if n < 0 {
+		return "-" + itoa(-n)
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func (c *Client) nodeQuery(ctx context.Context, query url.Values) (*QueryResult, error) {
+	var resp nodesResponse
+	if err := c.doRequest(ctx, "GET", "/node", query, nil); err != nil {
+		// doRequest with nil result won't unmarshal data, so we need raw approach
+		return nil, err
+	}
+	// We need to get the full paginated response, not just the data field.
+	// Use a raw request instead.
+	u := c.buildURL("/node", query)
+	req, err := c.rawRequest(ctx, "GET", u)
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Error) > 0 {
+		return nil, &APIError{StatusCode: resp.Status, Errors: resp.Error}
+	}
+	return &QueryResult{
+		Nodes:      resp.Data,
+		Limit:      resp.Limit,
+		Offset:     resp.Offset,
+		TotalCount: resp.TotalCount,
+	}, nil
+}
+
+func (c *Client) rawRequest(ctx context.Context, method, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	return req, nil
+}
+
+// Query searches for nodes with basic field matching.
+func (c *Client) Query(ctx context.Context, filters map[string]string, opts ...QueryOption) (*QueryResult, error) {
+	qcfg := &queryConfig{}
+	for _, opt := range opts {
+		opt(qcfg)
+	}
+	query := buildQueryValues(filters, qcfg, "query")
+	return c.nodeQuery(ctx, query)
+}
+
+// QueryFull searches for nodes with full querynode matching.
+func (c *Client) QueryFull(ctx context.Context, filters map[string]string, opts ...QueryOption) (*QueryResult, error) {
+	qcfg := &queryConfig{}
+	for _, opt := range opts {
+		opt(qcfg)
+	}
+	query := buildQueryValues(filters, qcfg, "querynode")
+	return c.nodeQuery(ctx, query)
+}
+
+// QueryDistinct returns distinct values for a field.
+func (c *Client) QueryDistinct(ctx context.Context, field string, filters map[string]string) (interface{}, error) {
+	query := url.Values{}
+	query.Set("distinct", field)
+	for k, v := range filters {
+		query.Set(k, v)
+	}
+	var result interface{}
+	if err := c.doRequest(ctx, "GET", "/node", query, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// QueryRaw performs a query with pre-built url.Values (backward compatibility).
+func (c *Client) QueryRaw(ctx context.Context, query url.Values) (*QueryResult, error) {
+	return c.nodeQuery(ctx, query)
+}
+
+// QueryDistinctRaw performs a distinct query with pre-built url.Values (backward compatibility).
+func (c *Client) QueryDistinctRaw(ctx context.Context, query url.Values) (interface{}, error) {
+	var result interface{}
+	if err := c.doRequest(ctx, "GET", "/node", query, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/clients/shock-go/server.go
+++ b/clients/shock-go/server.go
@@ -1,0 +1,32 @@
+package shock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ServerInfo retrieves server information from the root endpoint.
+// The root endpoint returns a bare struct, not envelope-wrapped.
+func (c *Client) ServerInfo(ctx context.Context) (*ServerInfo, error) {
+	u := c.buildURL("/", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	c.debugf("GET %s (server info)", u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var info ServerInfo
+	if err := json.NewDecoder(res.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("failed to decode server info: %w", err)
+	}
+	return &info, nil
+}

--- a/clients/shock-go/types.go
+++ b/clients/shock-go/types.go
@@ -1,0 +1,155 @@
+package shock
+
+import "time"
+
+// Node represents a Shock data node.
+type Node struct {
+	Id           string            `json:"id"`
+	Version      string            `json:"version"`
+	File         File              `json:"file"`
+	Attributes   interface{}       `json:"attributes"`
+	Indexes      map[string]*IdxInfo `json:"indexes"`
+	VersionParts map[string]string `json:"version_parts"`
+	Tags         []string          `json:"tags"`
+	Linkages     []Linkage         `json:"linkage"`
+	Priority     int               `json:"priority"`
+	CreatedOn    time.Time         `json:"created_on"`
+	LastModified time.Time         `json:"last_modified"`
+	Expiration   time.Time         `json:"expiration"`
+	Type         string            `json:"type"`
+	Parts        *PartsList        `json:"parts"`
+	Locations    []Location        `json:"locations"`
+	Restore      bool              `json:"restore"`
+}
+
+// File represents file metadata within a node.
+type File struct {
+	Name         string            `json:"name"`
+	Size         int64             `json:"size"`
+	Checksum     map[string]string `json:"checksum"`
+	Format       string            `json:"format"`
+	Virtual      bool              `json:"virtual"`
+	VirtualParts []string          `json:"virtual_parts"`
+	CreatedOn    time.Time         `json:"created_on"`
+	Locked       *LockInfo         `json:"locked"`
+}
+
+// LockInfo represents a lock on a file or index.
+type LockInfo struct {
+	CreatedOn time.Time `json:"created_on"`
+	Error     string    `json:"error"`
+}
+
+// IdxInfo represents index metadata.
+type IdxInfo struct {
+	TotalUnits  int64     `json:"total_units"`
+	AvgUnitSize int64     `json:"average_unit_size"`
+	CreatedOn   time.Time `json:"created_on"`
+	Locked      *LockInfo `json:"locked"`
+}
+
+// Linkage represents a relationship between nodes.
+type Linkage struct {
+	Type      string   `json:"relation"`
+	Ids       []string `json:"ids"`
+	Operation string   `json:"operation"`
+}
+
+// Location represents a storage location for a node.
+type Location struct {
+	ID            string     `json:"id"`
+	Stored        bool       `json:"stored,omitempty"`
+	RequestedDate *time.Time `json:"requestedDate,omitempty"`
+}
+
+// PartsList represents the parts metadata of a node.
+type PartsList struct {
+	Count       int        `json:"count"`
+	Length      int        `json:"length"`
+	VarLen      bool       `json:"varlen"`
+	Parts       [][]string `json:"parts"`
+	Compression string     `json:"compression"`
+}
+
+// DisplayAcl represents access control for a node.
+type DisplayAcl struct {
+	Owner  string    `json:"owner"`
+	Read   []string  `json:"read"`
+	Write  []string  `json:"write"`
+	Delete []string  `json:"delete"`
+	Public PublicAcl `json:"public"`
+}
+
+// PublicAcl represents public access flags.
+type PublicAcl struct {
+	Read   bool `json:"read"`
+	Write  bool `json:"write"`
+	Delete bool `json:"delete"`
+}
+
+// ServerInfo represents the root resource response from the Shock server.
+type ServerInfo struct {
+	AttributeIndexes []string `json:"attribute_indexes"`
+	Contact          string   `json:"contact"`
+	ID               string   `json:"id"`
+	Auth             []string `json:"auth"`
+	AnonPerms        AnonPerms `json:"anonymous_permissions"`
+	Resources        []string `json:"resources"`
+	ServerTime       string   `json:"server_time"`
+	Type             string   `json:"type"`
+	URL              string   `json:"url"`
+	Uptime           string   `json:"uptime"`
+	Version          string   `json:"version"`
+}
+
+// AnonPerms represents anonymous user permissions.
+type AnonPerms struct {
+	Read   bool `json:"read"`
+	Write  bool `json:"write"`
+	Delete bool `json:"delete"`
+}
+
+// PreAuthResponse represents a pre-authenticated download URL response.
+type PreAuthResponse struct {
+	Url       string `json:"url"`
+	ValidTill string `json:"validtill"`
+	Format    string `json:"format"`
+	Filename  string `json:"filename"`
+	Files     int    `json:"files"`
+	Size      int64  `json:"size"`
+}
+
+// Response envelopes (unexported).
+
+type nodeResponse struct {
+	Status int      `json:"status"`
+	Data   *Node    `json:"data"`
+	Error  []string `json:"error"`
+}
+
+type nodesResponse struct {
+	Status     int      `json:"status"`
+	Data       []Node   `json:"data"`
+	Error      []string `json:"error"`
+	Limit      int      `json:"limit"`
+	Offset     int      `json:"offset"`
+	TotalCount int      `json:"total_count"`
+}
+
+type aclResponse struct {
+	Status int         `json:"status"`
+	Data   *DisplayAcl `json:"data"`
+	Error  []string    `json:"error"`
+}
+
+type locationsResponse struct {
+	Status int        `json:"status"`
+	Data   []Location `json:"data"`
+	Error  []string   `json:"error"`
+}
+
+type preAuthResponseEnvelope struct {
+	Status int              `json:"status"`
+	Data   *PreAuthResponse `json:"data"`
+	Error  []string         `json:"error"`
+}

--- a/clients/shock-go/unpack.go
+++ b/clients/shock-go/unpack.go
@@ -1,0 +1,31 @@
+package shock
+
+import (
+	"context"
+	"path/filepath"
+)
+
+// UnpackArchiveNode unpacks an archive node into multiple nodes.
+func (c *Client) UnpackArchiveNode(ctx context.Context, nodeID, format, attrFile string) ([]Node, error) {
+	cfg := &createConfig{params: make(map[string]string)}
+	cfg.params["unpack_node"] = nodeID
+	cfg.params["archive_format"] = format
+	if attrFile != "" {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "attributes",
+			filename:  filepath.Base(attrFile),
+			path:      attrFile,
+		})
+	}
+
+	body, err := c.doMultipart(ctx, "POST", "/node", cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []Node
+	if err := c.checkErrors(body, 200, &nodes); err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}

--- a/clients/shock-go/upload.go
+++ b/clients/shock-go/upload.go
@@ -83,7 +83,10 @@ func WithFileContent(content string) CreateOption {
 // WithAttributes sets node attributes from a map (serialized as JSON).
 func WithAttributes(attrs map[string]interface{}) CreateOption {
 	return func(cfg *createConfig) {
-		b, _ := json.Marshal(attrs)
+		b, err := json.Marshal(attrs)
+		if err != nil {
+			return
+		}
 		cfg.params["attributes_str"] = string(b)
 	}
 }

--- a/clients/shock-go/upload.go
+++ b/clients/shock-go/upload.go
@@ -1,0 +1,239 @@
+package shock
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// createConfig holds all options for CreateNode/UpdateNode.
+type createConfig struct {
+	params map[string]string
+	files  []fileEntry
+}
+
+type fileEntry struct {
+	fieldName string
+	filename  string
+	path      string    // local file path (mutually exclusive with reader)
+	reader    io.Reader // in-memory data (mutually exclusive with path)
+}
+
+// CreateOption configures a CreateNode/UpdateNode call.
+type CreateOption func(*createConfig)
+
+func buildConfig(opts []CreateOption) *createConfig {
+	cfg := &createConfig{params: make(map[string]string)}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+// applyCompression renames "upload" field to compression format if set.
+func applyCompression(cfg *createConfig) {
+	comp, ok := cfg.params["_compression"]
+	if !ok {
+		return
+	}
+	delete(cfg.params, "_compression")
+	for i := range cfg.files {
+		if cfg.files[i].fieldName == "upload" {
+			cfg.files[i].fieldName = comp
+		}
+	}
+}
+
+// WithFile sets the upload file from an io.Reader.
+func WithFile(r io.Reader, filename string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "upload",
+			filename:  filename,
+			reader:    r,
+		})
+	}
+}
+
+// WithFilePath sets the upload file from a local file path.
+func WithFilePath(path string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "upload",
+			filename:  filepath.Base(path),
+			path:      path,
+		})
+	}
+}
+
+// WithFileContent sets the upload file from string content.
+func WithFileContent(content string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "upload",
+			filename:  "upload",
+			reader:    bytes.NewBufferString(content),
+		})
+	}
+}
+
+// WithAttributes sets node attributes from a map (serialized as JSON).
+func WithAttributes(attrs map[string]interface{}) CreateOption {
+	return func(cfg *createConfig) {
+		b, _ := json.Marshal(attrs)
+		cfg.params["attributes_str"] = string(b)
+	}
+}
+
+// WithAttributesFile sets node attributes from a JSON file.
+// Ignored if WithAttributes was already used.
+func WithAttributesFile(path string) CreateOption {
+	return func(cfg *createConfig) {
+		if _, ok := cfg.params["attributes_str"]; ok {
+			return
+		}
+		if path == "" {
+			return
+		}
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "attributes",
+			filename:  filepath.Base(path),
+			path:      path,
+		})
+	}
+}
+
+// WithExpiration sets the expiration for the node.
+func WithExpiration(exp string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["expiration"] = exp
+	}
+}
+
+// WithRemoveExpiration removes the expiration from the node.
+func WithRemoveExpiration() CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["remove_expiration"] = "1"
+	}
+}
+
+// WithFileName sets the filename for the node.
+func WithFileName(name string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["file_name"] = name
+	}
+}
+
+// WithCompression sets compression format ("gzip" or "bzip2").
+func WithCompression(format string) CreateOption {
+	return func(cfg *createConfig) {
+		if format != "" {
+			cfg.params["_compression"] = format
+		}
+	}
+}
+
+// WithParts initializes a parts node with the given number of parts.
+func WithParts(count int) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["parts"] = strconv.Itoa(count)
+	}
+}
+
+// WithPartsCompression sets the compression format for a parts node.
+func WithPartsCompression(format string) CreateOption {
+	return func(cfg *createConfig) {
+		if format != "" {
+			cfg.params["compression"] = format
+		}
+	}
+}
+
+// WithPart uploads a single part from an io.Reader.
+func WithPart(partNum int, r io.Reader, filename string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: strconv.Itoa(partNum),
+			filename:  filename,
+			reader:    r,
+		})
+	}
+}
+
+// WithPartFile uploads a single part from a file path.
+func WithPartFile(partNum int, path string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: strconv.Itoa(partNum),
+			filename:  filepath.Base(path),
+			path:      path,
+		})
+	}
+}
+
+// WithRemoteURL sets a remote URL for the node to fetch.
+func WithRemoteURL(url string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["upload_url"] = url
+	}
+}
+
+// WithVirtualParts creates a virtual node from the given node IDs.
+func WithVirtualParts(nodeIDs []string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["type"] = "virtual"
+		cfg.params["source"] = strings.Join(nodeIDs, ",")
+	}
+}
+
+// WithCopyData copies data from the specified source node.
+func WithCopyData(nodeID string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["copy_data"] = nodeID
+	}
+}
+
+// WithCopyIndexes copies indexes from the source node.
+func WithCopyIndexes() CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["copy_indexes"] = "1"
+	}
+}
+
+// WithCopyAttributes copies attributes from the source node.
+func WithCopyAttributes() CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["copy_attributes"] = "1"
+	}
+}
+
+// WithSubset creates a subset node from a parent node's index.
+func WithSubset(parentNodeID, parentIndex, subsetFile string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["parent_node"] = parentNodeID
+		cfg.params["parent_index"] = parentIndex
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "subset_indices",
+			filename:  filepath.Base(subsetFile),
+			path:      subsetFile,
+		})
+	}
+}
+
+// WithUnpackNode unpacks an archive node.
+func WithUnpackNode(nodeID, archiveFormat string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["unpack_node"] = nodeID
+		cfg.params["archive_format"] = archiveFormat
+	}
+}
+
+// WithChecksumMD5 sets the expected MD5 checksum for verification.
+func WithChecksumMD5(md5 string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["checksum-md5"] = md5
+	}
+}

--- a/clients/shock-go/wait.go
+++ b/clients/shock-go/wait.go
@@ -1,0 +1,106 @@
+package shock
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+var (
+	DefaultPollInterval = 30 * time.Second
+	DefaultWaitTimeout  = 1 * time.Hour
+)
+
+type waitConfig struct {
+	interval time.Duration
+	timeout  time.Duration
+}
+
+// WaitOption configures WaitFile/WaitIndex.
+type WaitOption func(*waitConfig)
+
+// WithPollInterval sets the polling interval.
+func WithPollInterval(d time.Duration) WaitOption {
+	return func(cfg *waitConfig) {
+		cfg.interval = d
+	}
+}
+
+// WithWaitTimeout sets the maximum wait time.
+func WithWaitTimeout(d time.Duration) WaitOption {
+	return func(cfg *waitConfig) {
+		cfg.timeout = d
+	}
+}
+
+// WaitFile polls until a node's file is no longer locked.
+func (c *Client) WaitFile(ctx context.Context, nodeID string, opts ...WaitOption) (*Node, error) {
+	cfg := waitConfig{interval: DefaultPollInterval, timeout: DefaultWaitTimeout}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	startTime := time.Now()
+	for {
+		node, err := c.GetNode(ctx, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		if node.File.Locked == nil {
+			return node, nil
+		}
+		if node.File.Locked.Error != "" {
+			return nil, fmt.Errorf("file lock error on node %s: %s", nodeID, node.File.Locked.Error)
+		}
+		if time.Since(startTime) > cfg.timeout {
+			return nil, fmt.Errorf("timeout waiting on file lock: node=%s", nodeID)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(cfg.interval):
+			// continue polling
+		}
+	}
+}
+
+// WaitIndex polls until a node's index is no longer locked.
+func (c *Client) WaitIndex(ctx context.Context, nodeID, indexName string, opts ...WaitOption) (*IdxInfo, error) {
+	if indexName == "" {
+		return nil, nil
+	}
+
+	cfg := waitConfig{interval: DefaultPollInterval, timeout: DefaultWaitTimeout}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	startTime := time.Now()
+	for {
+		node, err := c.GetNode(ctx, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		idx, has := node.Indexes[indexName]
+		if !has {
+			return nil, fmt.Errorf("index does not exist: node=%s, index=%s", nodeID, indexName)
+		}
+		if idx.Locked != nil && idx.Locked.Error != "" {
+			return nil, fmt.Errorf("index error: node=%s, index=%s, error=%s", nodeID, indexName, idx.Locked.Error)
+		}
+		if idx.Locked == nil {
+			return idx, nil
+		}
+		if time.Since(startTime) > cfg.timeout {
+			return nil, fmt.Errorf("timeout waiting on index lock: node=%s, index=%s", nodeID, indexName)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(cfg.interval):
+			// continue polling
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go v0.45.2-0.20190912001407-6ae710637747
 	github.com/Azure/azure-pipeline-go v0.2.2
 	github.com/Azure/azure-storage-blob-go v0.8.0
+	github.com/MG-RAST/Shock/clients/shock-go v0.0.0-00010101000000-000000000000
 	github.com/MG-RAST/go-shock-client v0.0.0-20190828185941-363c96852f00
 	github.com/MG-RAST/golib v0.0.0-20190510221542-86643de6f9e0
 	github.com/aws/aws-sdk-go v1.23.16-0.20190904183301-ed1c1dc0f009
@@ -37,3 +38,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/MG-RAST/Shock/clients/shock-go => ./clients/shock-go

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.2 h1:j8RI1yW0SkI+paT6uGwMlrMI/6zwYA6/CFil8rxOzGI=
 google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/shock-client/chunk.go
+++ b/shock-client/chunk.go
@@ -1,17 +1,18 @@
 package main
 
 import (
+	"context"
 	"crypto/md5"
 	"errors"
 	"fmt"
-	sc "github.com/MG-RAST/go-shock-client"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
 	"regexp"
 	"strconv"
+
+	sc "github.com/MG-RAST/Shock/clients/shock-go"
 )
 
 const MaxBuffer = 64 * 1024
@@ -38,7 +39,7 @@ func newChunkUploader(f string, c string) (cu chunkUploader) {
 	return
 }
 
-func (cu *chunkUploader) validateChunkNode(node *sc.ShockNode) (msg string) {
+func (cu *chunkUploader) validateChunkNode(node *sc.Node) (msg string) {
 	// basic check
 	if (node.Type != "parts") || (node.Parts == nil) {
 		return "node " + node.Id + " is not a valid parts node"
@@ -131,7 +132,7 @@ func (cu *chunkUploader) setMd5() {
 	cu.md5 = fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func (cu *chunkUploader) uploadParts(nid string, start int, dir string) (err error) {
+func (cu *chunkUploader) uploadParts(ctx context.Context, nid string, start int, dir string) (err error) {
 	if start >= cu.parts {
 		err = errors.New("invalid start position")
 		return
@@ -162,12 +163,12 @@ func (cu *chunkUploader) uploadParts(nid string, start int, dir string) (err err
 			if ferr == io.EOF {
 				break
 			}
-			ioutil.WriteFile(tempFile, byteBuffer, os.ModeAppend)
+			os.WriteFile(tempFile, byteBuffer, os.ModeAppend)
 			currSize += int64(bufferSize)
 		}
 		currSize = 0
 		// upload file part
-		_, err = client.PutOrPostFile(tempFile, nid, i, "", "", nil, nil)
+		_, err = client.UpdateNode(ctx, nid, sc.WithPartFile(i, tempFile))
 		if err != nil {
 			return
 		}

--- a/shock-client/shock-client.go
+++ b/shock-client/shock-client.go
@@ -1,14 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	sc "github.com/MG-RAST/go-shock-client"
 	"io"
 	"os"
 	"strconv"
+
+	sc "github.com/MG-RAST/Shock/clients/shock-go"
 )
 
-var client *sc.ShockClient
+var client *sc.Client
 
 func main() {
 	if len(os.Args) < 2 {
@@ -23,14 +25,15 @@ func main() {
 	flags.Parse(os.Args[2:])
 	args := flags.Args()
 
-	host, auth := getUserInfo()
-	client = sc.NewShockClient(host, auth, debug)
+	host, tkn, br := getUserInfo()
+	client = sc.New(host, sc.WithToken(tkn), sc.WithAuthType(br), sc.WithDebug(debug))
+	ctx := context.Background()
 
 	var err error
 	switch command {
 	case "info":
-		var info *sc.ShockResponseMap
-		info, err = client.ServerInfo()
+		var info *sc.ServerInfo
+		info, err = client.ServerInfo(ctx)
 		if err == nil {
 			exitOutput(&info)
 		}
@@ -61,18 +64,18 @@ func main() {
 				opts["compression"] = compression
 			}
 			opts["parts"] = strconv.Itoa(part)
-			nid, err = client.PutOrPostFile("", nid, 0, attributes, "parts", opts, nil)
+			nid, err = client.PutOrPostFile(ctx, "", nid, 0, attributes, "parts", opts, nil)
 		} else if (part > 0) && (filepath != "") && (command == "update") {
 			// put part file, update only
-			nid, err = client.PutOrPostFile(filepath, nid, part, attributes, "", opts, nil)
+			nid, err = client.PutOrPostFile(ctx, filepath, nid, part, attributes, "", opts, nil)
 		} else if virtual != "" {
 			// set virtual file
 			opts["virtual_file"] = virtual
-			nid, err = client.PutOrPostFile("", nid, 0, attributes, "virtual", opts, nil)
+			nid, err = client.PutOrPostFile(ctx, "", nid, 0, attributes, "virtual", opts, nil)
 		} else if remote != "" {
 			// add file by remote url
 			opts["remote_url"] = remote
-			nid, err = client.PutOrPostFile("", nid, 0, attributes, "remote", opts, nil)
+			nid, err = client.PutOrPostFile(ctx, "", nid, 0, attributes, "remote", opts, nil)
 		} else if copy != "" {
 			// copy file from another node
 			opts["parent_node"] = copy
@@ -80,7 +83,7 @@ func main() {
 			if attributes == "" {
 				opts["copy_attributes"] = "true"
 			}
-			nid, err = client.PutOrPostFile("", nid, 0, attributes, "copy", opts, nil)
+			nid, err = client.PutOrPostFile(ctx, "", nid, 0, attributes, "copy", opts, nil)
 		} else if (chunk != "") && (filepath != "") {
 			// special auto-parts upload, able to resume
 			if dir != "." && (!isDir(dir)) {
@@ -93,31 +96,31 @@ func main() {
 				opts["compression"] = compression
 			}
 			tempAttr := cu.getAttr()
-			nid, err = client.PutOrPostFile("", nid, 0, "", "parts", opts, tempAttr)
+			nid, err = client.PutOrPostFile(ctx, "", nid, 0, "", "parts", opts, tempAttr)
 			if err != nil {
 				exitError(err.Error())
 			}
 			// upload parts in series
-			err = cu.uploadParts(nid, 1, dir)
+			err = cu.uploadParts(ctx, nid, 1, dir)
 			if err != nil {
 				exitError("error uploading " + filepath + " in chunks: " + err.Error())
 			}
 			// final attributes
 			if attributes == "" {
 				attrMap := make(map[string]interface{})
-				client.UpdateAttributes(nid, "", attrMap)
+				client.UpdateAttributes(ctx, nid, "", attrMap)
 			} else {
-				client.UpdateAttributes(nid, attributes, nil)
+				client.UpdateAttributes(ctx, nid, attributes, nil)
 			}
 		} else if filepath != "" {
 			// basic file upload
 			if compression != "" {
 				opts["compression"] = compression
 			}
-			nid, err = client.PutOrPostFile(filepath, nid, 0, attributes, "", opts, nil)
+			nid, err = client.PutOrPostFile(ctx, filepath, nid, 0, attributes, "", opts, nil)
 		} else {
 			// just make empty node with provided options
-			nid, err = client.PutOrPostFile("", nid, 0, attributes, "", opts, nil)
+			nid, err = client.PutOrPostFile(ctx, "", nid, 0, attributes, "", opts, nil)
 		}
 		if err == nil {
 			fmt.Printf("%sd node: %s\n", command, nid)
@@ -132,8 +135,8 @@ func main() {
 		if filepath == "" {
 			exitError("missing required --filepath")
 		}
-		var node *sc.ShockNode
-		node, err = client.GetNode(args[0])
+		var node *sc.Node
+		node, err = client.GetNode(ctx, args[0])
 		if err != nil {
 			exitError(err.Error())
 		}
@@ -144,16 +147,16 @@ func main() {
 			exitError(errMsg)
 		}
 		// upload remaining parts in series
-		err = cu.uploadParts(args[0], node.Parts.Length+1, dir)
+		err = cu.uploadParts(ctx, args[0], node.Parts.Length+1, dir)
 		if err != nil {
 			exitError("error uploading " + filepath + " in chunks: " + err.Error())
 		}
 		// final attributes
 		if attributes == "" {
 			attrMap := make(map[string]interface{})
-			client.UpdateAttributes(args[0], "", attrMap)
+			client.UpdateAttributes(ctx, args[0], "", attrMap)
 		} else {
-			client.UpdateAttributes(args[0], attributes, nil)
+			client.UpdateAttributes(ctx, args[0], attributes, nil)
 		}
 	case "unpack":
 		if len(args) < 1 {
@@ -162,8 +165,8 @@ func main() {
 		if !validateCV("archive", archive) {
 			exitError("invalid archive type")
 		}
-		var nodes interface{}
-		nodes, err = client.UnpackArchiveNode(args[0], archive, attributes)
+		var nodes []sc.Node
+		nodes, err = client.UnpackArchiveNode(ctx, args[0], archive, attributes)
 		if err == nil {
 			exitOutput(&nodes)
 		}
@@ -177,18 +180,18 @@ func main() {
 		if (args[1] == "column") && (column < 1) {
 			exitError("invalid column position")
 		}
-		err = client.PutIndexQuery(args[0], args[1], force, column)
+		err = client.PutIndexQuery(ctx, args[0], args[1], force, column)
 	case "delete":
 		if len(args) < 1 {
 			exitError("missing required ID")
 		}
-		err = client.DeleteNode(args[0])
+		err = client.DeleteNode(ctx, args[0])
 	case "get":
 		if len(args) < 1 {
 			exitError("missing required ID")
 		}
-		var node *sc.ShockNode
-		node, err = client.GetNode(args[0])
+		var node *sc.Node
+		node, err = client.GetNode(ctx, args[0])
 		if err == nil {
 			exitOutput(&node)
 		}
@@ -204,23 +207,24 @@ func main() {
 		}
 		query.addOptions()
 		if query.distinct {
-			var srg *sc.ShockResponseGeneric
 			if query.full {
 				query.values.Set("querynode", "")
 			} else {
 				query.values.Set("query", "")
 			}
-			srg, err = client.QueryDistinct(query.values)
+			var result interface{}
+			result, err = client.QueryDistinctRaw(ctx, query.values)
 			if err == nil {
-				exitOutput(&srg)
+				exitOutput(&result)
 			}
 		} else {
-			var sqr *sc.ShockQueryResponse
 			if query.full {
-				sqr, err = client.QueryFull(query.values)
+				query.values.Set("querynode", "")
 			} else {
-				sqr, err = client.Query(query.values)
+				query.values.Set("query", "")
 			}
+			var sqr *sc.QueryResult
+			sqr, err = client.QueryRaw(ctx, query.values)
 			if err == nil {
 				exitOutput(&sqr)
 			}
@@ -229,38 +233,41 @@ func main() {
 		if len(args) < 1 {
 			exitError("missing required ID")
 		}
-		downUrl := buildDownloadUrl(host, args[0])
 		if (output == "") || (output == "-") || (output == "stdout") {
-			body, berr := sc.FetchShockStream(downUrl, auth)
+			body, berr := client.Download(ctx, args[0])
 			if berr != nil {
 				exitError(berr.Error())
 			}
 			defer body.Close()
 			_, err = io.Copy(os.Stdout, body)
 		} else {
+			var dlOpts []sc.DownloadOption
+			if md5sum {
+				dlOpts = append(dlOpts, sc.WithComputeMD5())
+			}
 			var size int64
 			var checksum string
-			size, checksum, err = sc.FetchFile(output, downUrl, auth, "", md5sum)
+			size, checksum, err = client.DownloadToFile(ctx, args[0], output, dlOpts...)
 			if err == nil {
 				fmt.Printf("download complete\nfile\t%s\nsize\t%d\nmd5\t%s\n", output, size, checksum)
 			}
 		}
 	case "acl":
 		if (len(args) > 1) && (args[1] == "get") {
-			var acl *sc.ShockResponseGeneric
-			acl, err = client.GetAcl(args[0])
+			var acl *sc.DisplayAcl
+			acl, err = client.GetAcl(ctx, args[0])
 			if err == nil {
-				exitOutput(&acl.Data)
+				exitOutput(&acl)
 			}
 		} else if len(args) > 3 {
 			if !validateCV("acl", args[2]) {
 				exitError("invalid acl type")
 			}
 			if args[1] == "add" {
-				err = client.PutAcl(args[0], args[2], args[3])
+				_, err = client.PutAcl(ctx, args[0], args[2], args[3])
 			}
 			if args[1] == "delete" {
-				err = client.DeleteAcl(args[0], args[2], args[3])
+				_, err = client.DeleteAcl(ctx, args[0], args[2], args[3])
 			}
 		} else {
 			exitError("missing required arguments")
@@ -270,16 +277,16 @@ func main() {
 			exitError("missing required arguments")
 		}
 		if args[1] == "add" {
-			err = client.MakePublic(args[0])
+			_, err = client.MakePublic(ctx, args[0])
 		}
 		if args[1] == "delete" {
-			err = client.DeleteAcl(args[0], "public_read", "")
+			_, err = client.DeleteAcl(ctx, args[0], "public_read", "")
 		}
 	case "chown":
 		if len(args) < 2 {
 			exitError("missing required arguments")
 		}
-		err = client.ChownNode(args[0], args[1])
+		_, err = client.ChownNode(ctx, args[0], args[1])
 	default:
 		exitError("invalid command: " + command)
 	}

--- a/shock-client/util.go
+++ b/shock-client/util.go
@@ -3,22 +3,19 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
-	"net/url"
 	"os"
-	"strconv"
 	"time"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 var CV = map[string]map[string]bool{
-	"acl":         map[string]bool{"all": true, "delete": true, "read": true, "write": true},
-	"archive":     map[string]bool{"tar": true, "tar.gz": true, "tar.bz2": true, "zip": true},
-	"compression": map[string]bool{"bzip2": true, "gzip": true},
-	"direction":   map[string]bool{"asc": true, "desc": true},
-	"index":       map[string]bool{"bai": true, "chunkrecord": true, "column": true, "line": true, "record": true, "size": true},
+	"acl":         {"all": true, "delete": true, "read": true, "write": true},
+	"archive":     {"tar": true, "tar.gz": true, "tar.bz2": true, "zip": true},
+	"compression": {"bzip2": true, "gzip": true},
+	"direction":   {"asc": true, "desc": true},
+	"index":       {"bai": true, "chunkrecord": true, "column": true, "line": true, "record": true, "size": true},
 }
 
 func validateCV(name string, value string) bool {
@@ -36,7 +33,6 @@ func exitHelp() {
 }
 
 func exitError(msg string) {
-	//fmt.Fprintln(os.Stderr, USAGE)
 	if msg != "" {
 		fmt.Fprintln(os.Stderr, "Error: "+msg)
 	}
@@ -58,7 +54,7 @@ func exitOutput(v interface{}) {
 		fmt.Println(string(b))
 	} else {
 		b = append(b, '\n')
-		e = ioutil.WriteFile(output, b, 0644)
+		e = os.WriteFile(output, b, 0644)
 		if e != nil {
 			exitError(e.Error())
 		}
@@ -66,7 +62,7 @@ func exitOutput(v interface{}) {
 	os.Exit(0)
 }
 
-func getUserInfo() (host string, auth string) {
+func getUserInfo() (host string, tkn string, br string) {
 	// set from env if exists
 	if os.Getenv("SHOCK_URL") != "" {
 		shock_url = os.Getenv("SHOCK_URL")
@@ -77,38 +73,14 @@ func getUserInfo() (host string, auth string) {
 	if os.Getenv("BEARER") != "" {
 		bearer = os.Getenv("BEARER")
 	}
-	// test and return
-	if token != "" {
-		auth = bearer + " " + token
-	}
 	host = shock_url
+	tkn = token
+	br = bearer
 	return
 }
 
 func buildDownloadUrl(host string, id string) string {
-	query := url.Values{}
-	query.Add("download", "")
-
-	if (index != "") && (parts != "") {
-		if !validateCV("index", index) {
-			exitError("invalid index type")
-		}
-		query.Add("index", index)
-		query.Add("part", parts)
-	} else if (seek > -1) && (length > 0) {
-		query.Add("seek", strconv.Itoa(seek))
-		query.Add("length", strconv.Itoa(length))
-	}
-
-	var myurl *url.URL
-	myurl, err := url.ParseRequestURI(host)
-	if err != nil {
-		exitError("error parsing shock url")
-	}
-	(*myurl).Path = "/node/" + id
-	(*myurl).RawQuery = query.Encode()
-
-	return myurl.String()
+	return host + "/node/" + id + "?download"
 }
 
 func isDir(d string) bool {

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/acl.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/acl.go
@@ -1,0 +1,61 @@
+package shock
+
+import (
+	"context"
+	"net/url"
+)
+
+// GetAcl retrieves the ACL for a node.
+func (c *Client) GetAcl(ctx context.Context, nodeID string) (*DisplayAcl, error) {
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "GET", "/node/"+nodeID+"/acl", nil, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// PutAcl adds users to an ACL type on a node.
+func (c *Client) PutAcl(ctx context.Context, nodeID, aclType, users string) (*DisplayAcl, error) {
+	query := url.Values{}
+	if users != "" {
+		query.Set("users", users)
+	}
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "PUT", "/node/"+nodeID+"/acl/"+aclType, query, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// DeleteAcl removes users from an ACL type on a node.
+func (c *Client) DeleteAcl(ctx context.Context, nodeID, aclType, users string) (*DisplayAcl, error) {
+	query := url.Values{}
+	if users != "" {
+		query.Set("users", users)
+	}
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "DELETE", "/node/"+nodeID+"/acl/"+aclType, query, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// MakePublic sets a node's read ACL to public.
+func (c *Client) MakePublic(ctx context.Context, nodeID string) (*DisplayAcl, error) {
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "PUT", "/node/"+nodeID+"/acl/public_read", nil, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}
+
+// ChownNode changes the owner of a node.
+func (c *Client) ChownNode(ctx context.Context, nodeID, user string) (*DisplayAcl, error) {
+	query := url.Values{}
+	query.Set("users", user)
+	var acl DisplayAcl
+	if err := c.doRequest(ctx, "PUT", "/node/"+nodeID+"/acl/owner", query, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/client.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/client.go
@@ -1,0 +1,66 @@
+package shock
+
+import (
+	"net/http"
+	"time"
+)
+
+// Client is a Shock API client.
+type Client struct {
+	baseURL    string
+	token      string
+	authType   string
+	httpClient *http.Client
+	debug      bool
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// New creates a new Shock client for the given base URL.
+func New(baseURL string, opts ...Option) *Client {
+	c := &Client{
+		baseURL:  baseURL,
+		authType: "OAuth",
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// WithToken sets the authentication token.
+func WithToken(token string) Option {
+	return func(c *Client) {
+		c.token = token
+	}
+}
+
+// WithAuthType sets the authorization type (e.g. "mgrast", "OAuth").
+func WithAuthType(authType string) Option {
+	return func(c *Client) {
+		c.authType = authType
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = hc
+	}
+}
+
+// WithDebug enables debug logging to stderr.
+func WithDebug(debug bool) Option {
+	return func(c *Client) {
+		c.debug = debug
+	}
+}
+
+// SetToken updates the authentication token.
+func (c *Client) SetToken(token string) {
+	c.token = token
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/download.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/download.go
@@ -127,14 +127,7 @@ func (c *Client) DownloadToFile(ctx context.Context, nodeID, filepath string, op
 		var src io.Reader = body
 		if cfg.computeMD5 {
 			// MD5 on compressed stream, then decompress
-			pReader, pWriter := io.Pipe()
-			defer pReader.Close()
-			dst := io.MultiWriter(pWriter, md5h)
-			go func() {
-				io.Copy(dst, body)
-				pWriter.Close()
-			}()
-			src = pReader
+			src = io.TeeReader(body, md5h)
 		}
 		gr, gerr := gzip.NewReader(src)
 		if gerr != nil {

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/download.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/download.go
@@ -1,0 +1,182 @@
+package shock
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+)
+
+type downloadConfig struct {
+	uncompress string
+	computeMD5 bool
+}
+
+// DownloadOption configures a DownloadToFile call.
+type DownloadOption func(*downloadConfig)
+
+// WithUncompress sets the decompression method for downloads (e.g. "gzip").
+func WithUncompress(method string) DownloadOption {
+	return func(cfg *downloadConfig) {
+		cfg.uncompress = method
+	}
+}
+
+// WithComputeMD5 enables MD5 checksum computation during download.
+func WithComputeMD5() DownloadOption {
+	return func(cfg *downloadConfig) {
+		cfg.computeMD5 = true
+	}
+}
+
+// Download streams a node's file data. The caller must close the returned ReadCloser.
+func (c *Client) Download(ctx context.Context, nodeID string) (io.ReadCloser, error) {
+	query := url.Values{"download": {""}}
+	u := c.buildURL("/node/"+nodeID, query)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	c.debugf("GET %s (download)", u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode == http.StatusOK {
+		return res.Body, nil
+	}
+
+	// Error response — parse JSON envelope
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	var envelope struct {
+		Error []string `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && len(envelope.Error) > 0 {
+		return nil, &APIError{StatusCode: res.StatusCode, Errors: envelope.Error}
+	}
+	return nil, &APIError{StatusCode: res.StatusCode, Errors: []string{string(body)}}
+}
+
+// DownloadRange streams a byte range from a node's file.
+func (c *Client) DownloadRange(ctx context.Context, nodeID string, seek, length int64) (io.ReadCloser, error) {
+	query := url.Values{
+		"download": {""},
+		"seek":     {strconv.FormatInt(seek, 10)},
+		"length":   {strconv.FormatInt(length, 10)},
+	}
+	u := c.buildURL("/node/"+nodeID, query)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode == http.StatusOK {
+		return res.Body, nil
+	}
+
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	var envelope struct {
+		Error []string `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && len(envelope.Error) > 0 {
+		return nil, &APIError{StatusCode: res.StatusCode, Errors: envelope.Error}
+	}
+	return nil, &APIError{StatusCode: res.StatusCode, Errors: []string{string(body)}}
+}
+
+// DownloadToFile downloads a node's file to a local path, optionally decompressing and computing MD5.
+func (c *Client) DownloadToFile(ctx context.Context, nodeID, filepath string, opts ...DownloadOption) (int64, string, error) {
+	cfg := &downloadConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	body, err := c.Download(ctx, nodeID)
+	if err != nil {
+		return 0, "", err
+	}
+	defer body.Close()
+
+	localFile, err := os.Create(filepath)
+	if err != nil {
+		return 0, "", err
+	}
+	defer localFile.Close()
+
+	md5h := md5.New()
+	var size int64
+
+	if cfg.uncompress == "gzip" {
+		var src io.Reader = body
+		if cfg.computeMD5 {
+			// MD5 on compressed stream, then decompress
+			pReader, pWriter := io.Pipe()
+			defer pReader.Close()
+			dst := io.MultiWriter(pWriter, md5h)
+			go func() {
+				io.Copy(dst, body)
+				pWriter.Close()
+			}()
+			src = pReader
+		}
+		gr, gerr := gzip.NewReader(src)
+		if gerr != nil {
+			return 0, "", gerr
+		}
+		defer gr.Close()
+		size, err = io.Copy(localFile, gr)
+		if err != nil {
+			return 0, "", err
+		}
+	} else {
+		var dst io.Writer
+		if cfg.computeMD5 {
+			dst = io.MultiWriter(localFile, md5h)
+		} else {
+			dst = localFile
+		}
+		size, err = io.Copy(dst, body)
+		if err != nil {
+			return 0, "", err
+		}
+	}
+
+	var md5sum string
+	if cfg.computeMD5 {
+		md5sum = fmt.Sprintf("%x", md5h.Sum(nil))
+	}
+	return size, md5sum, nil
+}
+
+// GetDownloadURL gets a pre-authenticated download URL for a node.
+func (c *Client) GetDownloadURL(ctx context.Context, nodeID string) (*PreAuthResponse, error) {
+	query := url.Values{"download_url": {""}}
+	var resp PreAuthResponse
+	if err := c.doRequest(ctx, "GET", "/node/"+nodeID, query, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DownloadURL returns the direct download URL for a node (no pre-auth).
+func (c *Client) DownloadURL(nodeID string) string {
+	query := url.Values{"download": {""}}
+	return c.buildURL("/node/"+nodeID, query)
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/errors.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/errors.go
@@ -1,0 +1,19 @@
+package shock
+
+import (
+	"fmt"
+	"strings"
+)
+
+// APIError represents an error returned by the Shock API.
+type APIError struct {
+	StatusCode int
+	Errors     []string
+}
+
+func (e *APIError) Error() string {
+	if len(e.Errors) > 0 {
+		return fmt.Sprintf("shock API error (status %d): %s", e.StatusCode, strings.Join(e.Errors, "; "))
+	}
+	return fmt.Sprintf("shock API error (status %d)", e.StatusCode)
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/helpers.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/helpers.go
@@ -1,0 +1,198 @@
+package shock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+// doRequest performs a JSON request with no body and parses the envelope response.
+func (c *Client) doRequest(ctx context.Context, method, path string, query url.Values, result interface{}) error {
+	u := c.buildURL(path, query)
+	req, err := http.NewRequestWithContext(ctx, method, u, nil)
+	if err != nil {
+		return err
+	}
+	c.setAuth(req)
+	c.debugf("%s %s", method, u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return c.checkErrors(body, res.StatusCode, result)
+}
+
+// doJSON sends a JSON body request and parses the envelope response.
+func (c *Client) doJSON(ctx context.Context, method, path string, payload interface{}, result interface{}) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	u := c.buildURL(path, nil)
+	req, err := http.NewRequestWithContext(ctx, method, u, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setAuth(req)
+	c.debugf("%s %s (json body)", method, u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return c.checkErrors(body, res.StatusCode, result)
+}
+
+// doMultipart builds a multipart form and sends it. Returns raw response body.
+func (c *Client) doMultipart(ctx context.Context, method, urlPath string, cfg *createConfig) ([]byte, error) {
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+
+	// Write form in a goroutine to stream data without buffering
+	errCh := make(chan error, 1)
+	go func() {
+		var writeErr error
+		defer func() {
+			// Close writer first to finalize the multipart boundary
+			writer.Close()
+			if writeErr != nil {
+				pw.CloseWithError(writeErr)
+			} else {
+				pw.Close()
+			}
+			errCh <- writeErr
+		}()
+
+		// Write string params
+		for k, v := range cfg.params {
+			if err := writer.WriteField(k, v); err != nil {
+				writeErr = err
+				return
+			}
+		}
+
+		// Write file fields
+		for _, f := range cfg.files {
+			part, err := writer.CreateFormFile(f.fieldName, f.filename)
+			if err != nil {
+				writeErr = err
+				return
+			}
+			if f.reader != nil {
+				if _, err := io.Copy(part, f.reader); err != nil {
+					writeErr = err
+					return
+				}
+			} else if f.path != "" {
+				fh, err := os.Open(f.path)
+				if err != nil {
+					writeErr = err
+					return
+				}
+				_, err = io.Copy(part, fh)
+				fh.Close()
+				if err != nil {
+					writeErr = err
+					return
+				}
+			}
+		}
+	}()
+
+	u := c.buildURL(urlPath, nil)
+	req, err := http.NewRequestWithContext(ctx, method, u, pr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	c.setAuth(req)
+	c.debugf("%s %s (multipart)", method, u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		// Also check goroutine error
+		if wErr := <-errCh; wErr != nil {
+			return nil, fmt.Errorf("multipart write error: %w; http error: %w", wErr, err)
+		}
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	// Wait for goroutine to finish
+	<-errCh
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// checkErrors parses the envelope response and extracts .Data into result.
+func (c *Client) checkErrors(body []byte, statusCode int, result interface{}) error {
+	var envelope struct {
+		Status int             `json:"status"`
+		Data   json.RawMessage `json:"data"`
+		Error  []string        `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return &APIError{StatusCode: statusCode, Errors: []string{string(body)}}
+	}
+	if len(envelope.Error) > 0 {
+		return &APIError{StatusCode: envelope.Status, Errors: envelope.Error}
+	}
+	if result != nil && len(envelope.Data) > 0 {
+		return json.Unmarshal(envelope.Data, result)
+	}
+	return nil
+}
+
+// setAuth adds the Authorization header if a token is set.
+func (c *Client) setAuth(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Authorization", c.authType+" "+c.token)
+	}
+}
+
+// buildURL constructs a full URL from base + path + query params.
+func (c *Client) buildURL(path string, query url.Values) string {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		// Fallback: concatenate directly
+		s := c.baseURL + path
+		if query != nil && len(query) > 0 {
+			s += "?" + query.Encode()
+		}
+		return s
+	}
+	u.Path = path
+	if query != nil && len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
+}
+
+// debugf prints debug output to stderr when debug mode is enabled.
+func (c *Client) debugf(format string, args ...interface{}) {
+	if c.debug {
+		fmt.Fprintf(os.Stderr, "[shock-client] "+format+"\n", args...)
+	}
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/helpers.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/helpers.go
@@ -128,10 +128,9 @@ func (c *Client) doMultipart(ctx context.Context, method, urlPath string, cfg *c
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		// Also check goroutine error
-		if wErr := <-errCh; wErr != nil {
-			return nil, fmt.Errorf("multipart write error: %w; http error: %w", wErr, err)
-		}
+		// Close the pipe reader to unblock the writer goroutine
+		pr.Close()
+		<-errCh
 		return nil, err
 	}
 	defer res.Body.Close()

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/index.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/index.go
@@ -1,0 +1,30 @@
+package shock
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+)
+
+// PutIndex creates or rebuilds an index on a node.
+func (c *Client) PutIndex(ctx context.Context, nodeID, indexName string) error {
+	if indexName == "" {
+		return nil
+	}
+	return c.doRequest(ctx, "PUT", "/node/"+nodeID+"/index/"+indexName, nil, nil)
+}
+
+// PutIndexQuery creates or rebuilds an index with options.
+func (c *Client) PutIndexQuery(ctx context.Context, nodeID, indexName string, force bool, column int) error {
+	if indexName == "" {
+		return nil
+	}
+	query := url.Values{}
+	if force {
+		query.Set("force_rebuild", "1")
+	}
+	if column > 0 {
+		query.Set("number", strconv.Itoa(column))
+	}
+	return c.doRequest(ctx, "PUT", "/node/"+nodeID+"/index/"+indexName, query, nil)
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/location.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/location.go
@@ -1,0 +1,35 @@
+package shock
+
+import "context"
+
+// GetLocations retrieves storage locations for a node.
+func (c *Client) GetLocations(ctx context.Context, nodeID string) ([]Location, error) {
+	var locs []Location
+	if err := c.doRequest(ctx, "GET", "/node/"+nodeID+"/locations/", nil, &locs); err != nil {
+		return nil, err
+	}
+	return locs, nil
+}
+
+// AddLocation adds a storage location to a node.
+func (c *Client) AddLocation(ctx context.Context, nodeID string, loc Location) ([]Location, error) {
+	var locs []Location
+	if err := c.doJSON(ctx, "POST", "/node/"+nodeID+"/locations/", loc, &locs); err != nil {
+		return nil, err
+	}
+	return locs, nil
+}
+
+// DeleteLocation removes a storage location from a node.
+func (c *Client) DeleteLocation(ctx context.Context, nodeID, locationID string) ([]Location, error) {
+	var locs []Location
+	if err := c.doRequest(ctx, "DELETE", "/node/"+nodeID+"/locations/"+locationID, nil, &locs); err != nil {
+		return nil, err
+	}
+	return locs, nil
+}
+
+// DeleteAllLocations removes all storage locations from a node.
+func (c *Client) DeleteAllLocations(ctx context.Context, nodeID string) error {
+	return c.doRequest(ctx, "DELETE", "/node/"+nodeID+"/locations/", nil, nil)
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/md5.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/md5.go
@@ -64,7 +64,7 @@ func (c *Client) PostFileLazy(ctx context.Context, filepath, filename string) (s
 
 		baseName := path.Base(filepath)
 		md5sumFileContent := md5sum + " " + baseName
-		if writeErr := os.WriteFile(md5Filename, []byte(md5sumFileContent), 0644); writeErr != nil {
+		if writeErr := os.WriteFile(md5Filename, []byte(md5sumFileContent), 0600); writeErr != nil {
 			c.debugf("PostFileLazy: could not write md5sum: %s, continuing", writeErr.Error())
 		}
 	} else {

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/md5.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/md5.go
@@ -1,0 +1,107 @@
+package shock
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+	"path"
+)
+
+// GetMD5FromFile computes the MD5 checksum of a file.
+func GetMD5FromFile(filepath string) (string, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// GetNodeByMD5 searches for an existing node with the given MD5 checksum.
+// Returns the node ID, whether a match was found, and any error.
+func (c *Client) GetNodeByMD5(ctx context.Context, md5sum string) (string, bool, error) {
+	filters := map[string]string{
+		"file.checksum.md5": md5sum,
+		"type":              "basic",
+	}
+	sr, err := c.QueryFull(ctx, filters)
+	if err != nil {
+		return "", false, err
+	}
+	if len(sr.Nodes) > 0 {
+		c.debugf("GetNodeByMD5: found existing node: %s", sr.Nodes[0].Id)
+		return sr.Nodes[0].Id, true, nil
+	}
+	c.debugf("GetNodeByMD5: file not found in Shock")
+	return "", false, nil
+}
+
+// PostFileLazy creates a node with a file, but first checks if a node with
+// the same MD5 already exists. If so, returns the existing node ID.
+// It caches MD5 checksums in .md5 files alongside the source file.
+func (c *Client) PostFileLazy(ctx context.Context, filepath, filename string) (string, error) {
+	md5Filename := filepath + ".md5"
+	var md5sum string
+
+	c.debugf("PostFileLazy: filepath=%s (md5Filename=%s)", filepath, md5Filename)
+
+	if _, err := os.Stat(md5Filename); err != nil {
+		// .md5 file not found, calculate
+		c.debugf("PostFileLazy: calculating md5sum...")
+		var calcErr error
+		md5sum, calcErr = GetMD5FromFile(filepath)
+		if calcErr != nil {
+			return "", fmt.Errorf("GetMD5FromFile: %w", calcErr)
+		}
+		c.debugf("PostFileLazy: calculated md5sum: %s", md5sum)
+
+		baseName := path.Base(filepath)
+		md5sumFileContent := md5sum + " " + baseName
+		if writeErr := os.WriteFile(md5Filename, []byte(md5sumFileContent), 0644); writeErr != nil {
+			c.debugf("PostFileLazy: could not write md5sum: %s, continuing", writeErr.Error())
+		}
+	} else {
+		// .md5 file exists
+		md5sumBytes, readErr := os.ReadFile(md5Filename)
+		if readErr != nil {
+			return "", fmt.Errorf("could not read md5sum file: %w", readErr)
+		}
+		if len(md5sumBytes) >= 32 {
+			md5sum = string(md5sumBytes[0:32])
+		}
+		c.debugf("PostFileLazy: got cached md5sum: %s", md5sum)
+	}
+
+	if md5sum != "" {
+		nodeid, ok, err := c.GetNodeByMD5(ctx, md5sum)
+		if err != nil {
+			c.debugf("PostFileLazy: GetNodeByMD5 error: %s", err.Error())
+		} else if ok {
+			return nodeid, nil
+		}
+	}
+
+	// File not found in Shock, upload it
+	var opts []CreateOption
+	if filepath != "" {
+		opts = append(opts, WithFilePath(filepath))
+	}
+	if filename != "" {
+		opts = append(opts, WithFileName(filename))
+	}
+	node, err := c.CreateNode(ctx, opts...)
+	if err != nil {
+		return "", err
+	}
+	if node != nil {
+		return node.Id, nil
+	}
+	return "", nil
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/node.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/node.go
@@ -1,0 +1,205 @@
+package shock
+
+import (
+	"context"
+	"net/url"
+)
+
+// GetNode retrieves a node by ID.
+func (c *Client) GetNode(ctx context.Context, id string) (*Node, error) {
+	var node Node
+	if err := c.doRequest(ctx, "GET", "/node/"+id, nil, &node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+// DeleteNode deletes a node by ID.
+func (c *Client) DeleteNode(ctx context.Context, id string) error {
+	return c.doRequest(ctx, "DELETE", "/node/"+id, nil, nil)
+}
+
+// CreateNode creates a new node with the given options.
+func (c *Client) CreateNode(ctx context.Context, opts ...CreateOption) (*Node, error) {
+	cfg := buildConfig(opts)
+	applyCompression(cfg)
+
+	body, err := c.doMultipart(ctx, "POST", "/node", cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var node Node
+	if err := c.checkErrors(body, 200, &node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+// UpdateNode updates an existing node with the given options.
+func (c *Client) UpdateNode(ctx context.Context, id string, opts ...CreateOption) (*Node, error) {
+	cfg := buildConfig(opts)
+	applyCompression(cfg)
+
+	body, err := c.doMultipart(ctx, "PUT", "/node/"+id, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var node Node
+	if err := c.checkErrors(body, 200, &node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+// UpdateAttributes updates the attributes of an existing node.
+func (c *Client) UpdateAttributes(ctx context.Context, id string, attrFile string, nodeattr map[string]interface{}) error {
+	var opts []CreateOption
+	if attrFile != "" {
+		opts = append(opts, WithAttributesFile(attrFile))
+	}
+	if len(nodeattr) > 0 {
+		opts = append(opts, WithAttributes(nodeattr))
+	}
+	_, err := c.UpdateNode(ctx, id, opts...)
+	return err
+}
+
+// PostFileWithAttributes creates a node with a file and attributes.
+func (c *Client) PostFileWithAttributes(ctx context.Context, filepath, filename string, nodeattr map[string]interface{}) (*Node, error) {
+	opts := []CreateOption{WithFilePath(filepath)}
+	if filename != "" {
+		opts = append(opts, WithFileName(filename))
+	}
+	if len(nodeattr) > 0 {
+		opts = append(opts, WithAttributes(nodeattr))
+	}
+	return c.CreateNode(ctx, opts...)
+}
+
+// PutOrPostFile provides backward compatibility with the old client.
+// If nodeid is empty, creates a new node (POST); otherwise updates (PUT).
+func (c *Client) PutOrPostFile(ctx context.Context, filename, nodeid string, rank int, attrfile, ntype string, formopts map[string]string, nodeattr map[string]interface{}) (string, error) {
+	var opts []CreateOption
+
+	// Attributes
+	if attrfile != "" && rank < 2 {
+		opts = append(opts, WithAttributesFile(attrfile))
+	}
+	if len(nodeattr) > 0 {
+		opts = append(opts, WithAttributes(nodeattr))
+	}
+
+	// Form options
+	if v, ok := formopts["file_name"]; ok {
+		opts = append(opts, WithFileName(v))
+	}
+	if v, ok := formopts["expiration"]; ok {
+		opts = append(opts, WithExpiration(v))
+	}
+	if _, ok := formopts["remove_expiration"]; ok {
+		opts = append(opts, WithRemoveExpiration())
+	}
+
+	compression := formopts["compression"]
+
+	if rank > 0 && filename == "" {
+		// Parts node initialization
+		opts = append(opts, WithParts(rank))
+		if compression != "" {
+			opts = append(opts, WithPartsCompression(compression))
+		}
+		// Also handle file_name from parts option
+		if v, ok := formopts["parts"]; ok {
+			n, _ := url.QueryUnescape(v)
+			_ = n
+		}
+	} else if rank > 0 && filename != "" {
+		// Part upload
+		opts = append(opts, WithPartFile(rank, filename))
+	} else {
+		// Handle different node types
+		switch ntype {
+		case "virtual":
+			if v, ok := formopts["virtual_file"]; ok {
+				opts = append(opts, WithVirtualParts(splitComma(v)))
+			}
+		case "remote":
+			if v, ok := formopts["remote_url"]; ok {
+				opts = append(opts, WithRemoteURL(v))
+			}
+		case "copy":
+			if v, ok := formopts["parent_node"]; ok {
+				opts = append(opts, WithCopyData(v))
+			}
+			if _, ok := formopts["copy_indexes"]; ok {
+				opts = append(opts, WithCopyIndexes())
+			}
+			if _, ok := formopts["copy_attributes"]; ok {
+				opts = append(opts, WithCopyAttributes())
+			}
+		case "parts":
+			if v, ok := formopts["parts"]; ok {
+				opts = append(opts, withPartsString(v))
+			}
+			if compression != "" {
+				opts = append(opts, WithPartsCompression(compression))
+			}
+		default:
+			if filename != "" {
+				opts = append(opts, WithFilePath(filename))
+				if compression != "" {
+					opts = append(opts, WithCompression(compression))
+				}
+			}
+		}
+	}
+
+	var node *Node
+	var err error
+	if nodeid != "" {
+		node, err = c.UpdateNode(ctx, nodeid, opts...)
+	} else {
+		node, err = c.CreateNode(ctx, opts...)
+	}
+	if err != nil {
+		return "", err
+	}
+	if node != nil {
+		return node.Id, nil
+	}
+	return "", nil
+}
+
+func splitComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := make([]string, 0)
+	for _, p := range splitStr(s, ',') {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+func splitStr(s string, sep byte) []string {
+	var result []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	result = append(result, s[start:])
+	return result
+}
+
+func withPartsString(s string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["parts"] = s
+	}
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/node.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/node.go
@@ -1,9 +1,6 @@
 package shock
 
-import (
-	"context"
-	"net/url"
-)
+import "context"
 
 // GetNode retrieves a node by ID.
 func (c *Client) GetNode(ctx context.Context, id string) (*Node, error) {
@@ -109,11 +106,6 @@ func (c *Client) PutOrPostFile(ctx context.Context, filename, nodeid string, ran
 		opts = append(opts, WithParts(rank))
 		if compression != "" {
 			opts = append(opts, WithPartsCompression(compression))
-		}
-		// Also handle file_name from parts option
-		if v, ok := formopts["parts"]; ok {
-			n, _ := url.QueryUnescape(v)
-			_ = n
 		}
 	} else if rank > 0 && filename != "" {
 		// Part upload

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/query.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/query.go
@@ -97,12 +97,6 @@ func itoa(n int) string {
 
 func (c *Client) nodeQuery(ctx context.Context, query url.Values) (*QueryResult, error) {
 	var resp nodesResponse
-	if err := c.doRequest(ctx, "GET", "/node", query, nil); err != nil {
-		// doRequest with nil result won't unmarshal data, so we need raw approach
-		return nil, err
-	}
-	// We need to get the full paginated response, not just the data field.
-	// Use a raw request instead.
 	u := c.buildURL("/node", query)
 	req, err := c.rawRequest(ctx, "GET", u)
 	if err != nil {

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/query.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/query.go
@@ -1,0 +1,185 @@
+package shock
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// QueryResult holds the result of a node query.
+type QueryResult struct {
+	Nodes      []Node
+	Limit      int
+	Offset     int
+	TotalCount int
+}
+
+type queryConfig struct {
+	limit     int
+	offset    int
+	order     string
+	direction string
+}
+
+// QueryOption configures a Query call.
+type QueryOption func(*queryConfig)
+
+// WithLimit sets the maximum number of results.
+func WithLimit(n int) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.limit = n
+	}
+}
+
+// WithOffset sets the starting offset.
+func WithOffset(n int) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.offset = n
+	}
+}
+
+// WithOrder sets the field to sort by.
+func WithOrder(field string) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.order = field
+	}
+}
+
+// WithDirection sets the sort direction ("asc" or "desc").
+func WithDirection(dir string) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.direction = dir
+	}
+}
+
+func buildQueryValues(filters map[string]string, qcfg *queryConfig, queryType string) url.Values {
+	query := url.Values{}
+	query.Set(queryType, "")
+	for k, v := range filters {
+		query.Set(k, v)
+	}
+	if qcfg.limit > 0 {
+		query.Set("limit", intToStr(qcfg.limit))
+	}
+	if qcfg.offset > 0 {
+		query.Set("offset", intToStr(qcfg.offset))
+	}
+	if qcfg.order != "" {
+		query.Set("order", qcfg.order)
+	}
+	if qcfg.direction != "" {
+		query.Set("direction", qcfg.direction)
+	}
+	return query
+}
+
+func intToStr(n int) string {
+	return url.QueryEscape(json.Number(itoa(n)).String())
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	if n < 0 {
+		return "-" + itoa(-n)
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func (c *Client) nodeQuery(ctx context.Context, query url.Values) (*QueryResult, error) {
+	var resp nodesResponse
+	if err := c.doRequest(ctx, "GET", "/node", query, nil); err != nil {
+		// doRequest with nil result won't unmarshal data, so we need raw approach
+		return nil, err
+	}
+	// We need to get the full paginated response, not just the data field.
+	// Use a raw request instead.
+	u := c.buildURL("/node", query)
+	req, err := c.rawRequest(ctx, "GET", u)
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Error) > 0 {
+		return nil, &APIError{StatusCode: resp.Status, Errors: resp.Error}
+	}
+	return &QueryResult{
+		Nodes:      resp.Data,
+		Limit:      resp.Limit,
+		Offset:     resp.Offset,
+		TotalCount: resp.TotalCount,
+	}, nil
+}
+
+func (c *Client) rawRequest(ctx context.Context, method, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	return req, nil
+}
+
+// Query searches for nodes with basic field matching.
+func (c *Client) Query(ctx context.Context, filters map[string]string, opts ...QueryOption) (*QueryResult, error) {
+	qcfg := &queryConfig{}
+	for _, opt := range opts {
+		opt(qcfg)
+	}
+	query := buildQueryValues(filters, qcfg, "query")
+	return c.nodeQuery(ctx, query)
+}
+
+// QueryFull searches for nodes with full querynode matching.
+func (c *Client) QueryFull(ctx context.Context, filters map[string]string, opts ...QueryOption) (*QueryResult, error) {
+	qcfg := &queryConfig{}
+	for _, opt := range opts {
+		opt(qcfg)
+	}
+	query := buildQueryValues(filters, qcfg, "querynode")
+	return c.nodeQuery(ctx, query)
+}
+
+// QueryDistinct returns distinct values for a field.
+func (c *Client) QueryDistinct(ctx context.Context, field string, filters map[string]string) (interface{}, error) {
+	query := url.Values{}
+	query.Set("distinct", field)
+	for k, v := range filters {
+		query.Set(k, v)
+	}
+	var result interface{}
+	if err := c.doRequest(ctx, "GET", "/node", query, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// QueryRaw performs a query with pre-built url.Values (backward compatibility).
+func (c *Client) QueryRaw(ctx context.Context, query url.Values) (*QueryResult, error) {
+	return c.nodeQuery(ctx, query)
+}
+
+// QueryDistinctRaw performs a distinct query with pre-built url.Values (backward compatibility).
+func (c *Client) QueryDistinctRaw(ctx context.Context, query url.Values) (interface{}, error) {
+	var result interface{}
+	if err := c.doRequest(ctx, "GET", "/node", query, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/server.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/server.go
@@ -1,0 +1,32 @@
+package shock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ServerInfo retrieves server information from the root endpoint.
+// The root endpoint returns a bare struct, not envelope-wrapped.
+func (c *Client) ServerInfo(ctx context.Context) (*ServerInfo, error) {
+	u := c.buildURL("/", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	c.debugf("GET %s (server info)", u)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var info ServerInfo
+	if err := json.NewDecoder(res.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("failed to decode server info: %w", err)
+	}
+	return &info, nil
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/types.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/types.go
@@ -1,0 +1,155 @@
+package shock
+
+import "time"
+
+// Node represents a Shock data node.
+type Node struct {
+	Id           string            `json:"id"`
+	Version      string            `json:"version"`
+	File         File              `json:"file"`
+	Attributes   interface{}       `json:"attributes"`
+	Indexes      map[string]*IdxInfo `json:"indexes"`
+	VersionParts map[string]string `json:"version_parts"`
+	Tags         []string          `json:"tags"`
+	Linkages     []Linkage         `json:"linkage"`
+	Priority     int               `json:"priority"`
+	CreatedOn    time.Time         `json:"created_on"`
+	LastModified time.Time         `json:"last_modified"`
+	Expiration   time.Time         `json:"expiration"`
+	Type         string            `json:"type"`
+	Parts        *PartsList        `json:"parts"`
+	Locations    []Location        `json:"locations"`
+	Restore      bool              `json:"restore"`
+}
+
+// File represents file metadata within a node.
+type File struct {
+	Name         string            `json:"name"`
+	Size         int64             `json:"size"`
+	Checksum     map[string]string `json:"checksum"`
+	Format       string            `json:"format"`
+	Virtual      bool              `json:"virtual"`
+	VirtualParts []string          `json:"virtual_parts"`
+	CreatedOn    time.Time         `json:"created_on"`
+	Locked       *LockInfo         `json:"locked"`
+}
+
+// LockInfo represents a lock on a file or index.
+type LockInfo struct {
+	CreatedOn time.Time `json:"created_on"`
+	Error     string    `json:"error"`
+}
+
+// IdxInfo represents index metadata.
+type IdxInfo struct {
+	TotalUnits  int64     `json:"total_units"`
+	AvgUnitSize int64     `json:"average_unit_size"`
+	CreatedOn   time.Time `json:"created_on"`
+	Locked      *LockInfo `json:"locked"`
+}
+
+// Linkage represents a relationship between nodes.
+type Linkage struct {
+	Type      string   `json:"relation"`
+	Ids       []string `json:"ids"`
+	Operation string   `json:"operation"`
+}
+
+// Location represents a storage location for a node.
+type Location struct {
+	ID            string     `json:"id"`
+	Stored        bool       `json:"stored,omitempty"`
+	RequestedDate *time.Time `json:"requestedDate,omitempty"`
+}
+
+// PartsList represents the parts metadata of a node.
+type PartsList struct {
+	Count       int        `json:"count"`
+	Length      int        `json:"length"`
+	VarLen      bool       `json:"varlen"`
+	Parts       [][]string `json:"parts"`
+	Compression string     `json:"compression"`
+}
+
+// DisplayAcl represents access control for a node.
+type DisplayAcl struct {
+	Owner  string    `json:"owner"`
+	Read   []string  `json:"read"`
+	Write  []string  `json:"write"`
+	Delete []string  `json:"delete"`
+	Public PublicAcl `json:"public"`
+}
+
+// PublicAcl represents public access flags.
+type PublicAcl struct {
+	Read   bool `json:"read"`
+	Write  bool `json:"write"`
+	Delete bool `json:"delete"`
+}
+
+// ServerInfo represents the root resource response from the Shock server.
+type ServerInfo struct {
+	AttributeIndexes []string `json:"attribute_indexes"`
+	Contact          string   `json:"contact"`
+	ID               string   `json:"id"`
+	Auth             []string `json:"auth"`
+	AnonPerms        AnonPerms `json:"anonymous_permissions"`
+	Resources        []string `json:"resources"`
+	ServerTime       string   `json:"server_time"`
+	Type             string   `json:"type"`
+	URL              string   `json:"url"`
+	Uptime           string   `json:"uptime"`
+	Version          string   `json:"version"`
+}
+
+// AnonPerms represents anonymous user permissions.
+type AnonPerms struct {
+	Read   bool `json:"read"`
+	Write  bool `json:"write"`
+	Delete bool `json:"delete"`
+}
+
+// PreAuthResponse represents a pre-authenticated download URL response.
+type PreAuthResponse struct {
+	Url       string `json:"url"`
+	ValidTill string `json:"validtill"`
+	Format    string `json:"format"`
+	Filename  string `json:"filename"`
+	Files     int    `json:"files"`
+	Size      int64  `json:"size"`
+}
+
+// Response envelopes (unexported).
+
+type nodeResponse struct {
+	Status int      `json:"status"`
+	Data   *Node    `json:"data"`
+	Error  []string `json:"error"`
+}
+
+type nodesResponse struct {
+	Status     int      `json:"status"`
+	Data       []Node   `json:"data"`
+	Error      []string `json:"error"`
+	Limit      int      `json:"limit"`
+	Offset     int      `json:"offset"`
+	TotalCount int      `json:"total_count"`
+}
+
+type aclResponse struct {
+	Status int         `json:"status"`
+	Data   *DisplayAcl `json:"data"`
+	Error  []string    `json:"error"`
+}
+
+type locationsResponse struct {
+	Status int        `json:"status"`
+	Data   []Location `json:"data"`
+	Error  []string   `json:"error"`
+}
+
+type preAuthResponseEnvelope struct {
+	Status int              `json:"status"`
+	Data   *PreAuthResponse `json:"data"`
+	Error  []string         `json:"error"`
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/unpack.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/unpack.go
@@ -1,0 +1,31 @@
+package shock
+
+import (
+	"context"
+	"path/filepath"
+)
+
+// UnpackArchiveNode unpacks an archive node into multiple nodes.
+func (c *Client) UnpackArchiveNode(ctx context.Context, nodeID, format, attrFile string) ([]Node, error) {
+	cfg := &createConfig{params: make(map[string]string)}
+	cfg.params["unpack_node"] = nodeID
+	cfg.params["archive_format"] = format
+	if attrFile != "" {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "attributes",
+			filename:  filepath.Base(attrFile),
+			path:      attrFile,
+		})
+	}
+
+	body, err := c.doMultipart(ctx, "POST", "/node", cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []Node
+	if err := c.checkErrors(body, 200, &nodes); err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/upload.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/upload.go
@@ -83,7 +83,10 @@ func WithFileContent(content string) CreateOption {
 // WithAttributes sets node attributes from a map (serialized as JSON).
 func WithAttributes(attrs map[string]interface{}) CreateOption {
 	return func(cfg *createConfig) {
-		b, _ := json.Marshal(attrs)
+		b, err := json.Marshal(attrs)
+		if err != nil {
+			return
+		}
 		cfg.params["attributes_str"] = string(b)
 	}
 }

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/upload.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/upload.go
@@ -1,0 +1,239 @@
+package shock
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// createConfig holds all options for CreateNode/UpdateNode.
+type createConfig struct {
+	params map[string]string
+	files  []fileEntry
+}
+
+type fileEntry struct {
+	fieldName string
+	filename  string
+	path      string    // local file path (mutually exclusive with reader)
+	reader    io.Reader // in-memory data (mutually exclusive with path)
+}
+
+// CreateOption configures a CreateNode/UpdateNode call.
+type CreateOption func(*createConfig)
+
+func buildConfig(opts []CreateOption) *createConfig {
+	cfg := &createConfig{params: make(map[string]string)}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+// applyCompression renames "upload" field to compression format if set.
+func applyCompression(cfg *createConfig) {
+	comp, ok := cfg.params["_compression"]
+	if !ok {
+		return
+	}
+	delete(cfg.params, "_compression")
+	for i := range cfg.files {
+		if cfg.files[i].fieldName == "upload" {
+			cfg.files[i].fieldName = comp
+		}
+	}
+}
+
+// WithFile sets the upload file from an io.Reader.
+func WithFile(r io.Reader, filename string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "upload",
+			filename:  filename,
+			reader:    r,
+		})
+	}
+}
+
+// WithFilePath sets the upload file from a local file path.
+func WithFilePath(path string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "upload",
+			filename:  filepath.Base(path),
+			path:      path,
+		})
+	}
+}
+
+// WithFileContent sets the upload file from string content.
+func WithFileContent(content string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "upload",
+			filename:  "upload",
+			reader:    bytes.NewBufferString(content),
+		})
+	}
+}
+
+// WithAttributes sets node attributes from a map (serialized as JSON).
+func WithAttributes(attrs map[string]interface{}) CreateOption {
+	return func(cfg *createConfig) {
+		b, _ := json.Marshal(attrs)
+		cfg.params["attributes_str"] = string(b)
+	}
+}
+
+// WithAttributesFile sets node attributes from a JSON file.
+// Ignored if WithAttributes was already used.
+func WithAttributesFile(path string) CreateOption {
+	return func(cfg *createConfig) {
+		if _, ok := cfg.params["attributes_str"]; ok {
+			return
+		}
+		if path == "" {
+			return
+		}
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "attributes",
+			filename:  filepath.Base(path),
+			path:      path,
+		})
+	}
+}
+
+// WithExpiration sets the expiration for the node.
+func WithExpiration(exp string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["expiration"] = exp
+	}
+}
+
+// WithRemoveExpiration removes the expiration from the node.
+func WithRemoveExpiration() CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["remove_expiration"] = "1"
+	}
+}
+
+// WithFileName sets the filename for the node.
+func WithFileName(name string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["file_name"] = name
+	}
+}
+
+// WithCompression sets compression format ("gzip" or "bzip2").
+func WithCompression(format string) CreateOption {
+	return func(cfg *createConfig) {
+		if format != "" {
+			cfg.params["_compression"] = format
+		}
+	}
+}
+
+// WithParts initializes a parts node with the given number of parts.
+func WithParts(count int) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["parts"] = strconv.Itoa(count)
+	}
+}
+
+// WithPartsCompression sets the compression format for a parts node.
+func WithPartsCompression(format string) CreateOption {
+	return func(cfg *createConfig) {
+		if format != "" {
+			cfg.params["compression"] = format
+		}
+	}
+}
+
+// WithPart uploads a single part from an io.Reader.
+func WithPart(partNum int, r io.Reader, filename string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: strconv.Itoa(partNum),
+			filename:  filename,
+			reader:    r,
+		})
+	}
+}
+
+// WithPartFile uploads a single part from a file path.
+func WithPartFile(partNum int, path string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: strconv.Itoa(partNum),
+			filename:  filepath.Base(path),
+			path:      path,
+		})
+	}
+}
+
+// WithRemoteURL sets a remote URL for the node to fetch.
+func WithRemoteURL(url string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["upload_url"] = url
+	}
+}
+
+// WithVirtualParts creates a virtual node from the given node IDs.
+func WithVirtualParts(nodeIDs []string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["type"] = "virtual"
+		cfg.params["source"] = strings.Join(nodeIDs, ",")
+	}
+}
+
+// WithCopyData copies data from the specified source node.
+func WithCopyData(nodeID string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["copy_data"] = nodeID
+	}
+}
+
+// WithCopyIndexes copies indexes from the source node.
+func WithCopyIndexes() CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["copy_indexes"] = "1"
+	}
+}
+
+// WithCopyAttributes copies attributes from the source node.
+func WithCopyAttributes() CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["copy_attributes"] = "1"
+	}
+}
+
+// WithSubset creates a subset node from a parent node's index.
+func WithSubset(parentNodeID, parentIndex, subsetFile string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["parent_node"] = parentNodeID
+		cfg.params["parent_index"] = parentIndex
+		cfg.files = append(cfg.files, fileEntry{
+			fieldName: "subset_indices",
+			filename:  filepath.Base(subsetFile),
+			path:      subsetFile,
+		})
+	}
+}
+
+// WithUnpackNode unpacks an archive node.
+func WithUnpackNode(nodeID, archiveFormat string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["unpack_node"] = nodeID
+		cfg.params["archive_format"] = archiveFormat
+	}
+}
+
+// WithChecksumMD5 sets the expected MD5 checksum for verification.
+func WithChecksumMD5(md5 string) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.params["checksum-md5"] = md5
+	}
+}

--- a/vendor/github.com/MG-RAST/Shock/clients/shock-go/wait.go
+++ b/vendor/github.com/MG-RAST/Shock/clients/shock-go/wait.go
@@ -1,0 +1,106 @@
+package shock
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+var (
+	DefaultPollInterval = 30 * time.Second
+	DefaultWaitTimeout  = 1 * time.Hour
+)
+
+type waitConfig struct {
+	interval time.Duration
+	timeout  time.Duration
+}
+
+// WaitOption configures WaitFile/WaitIndex.
+type WaitOption func(*waitConfig)
+
+// WithPollInterval sets the polling interval.
+func WithPollInterval(d time.Duration) WaitOption {
+	return func(cfg *waitConfig) {
+		cfg.interval = d
+	}
+}
+
+// WithWaitTimeout sets the maximum wait time.
+func WithWaitTimeout(d time.Duration) WaitOption {
+	return func(cfg *waitConfig) {
+		cfg.timeout = d
+	}
+}
+
+// WaitFile polls until a node's file is no longer locked.
+func (c *Client) WaitFile(ctx context.Context, nodeID string, opts ...WaitOption) (*Node, error) {
+	cfg := waitConfig{interval: DefaultPollInterval, timeout: DefaultWaitTimeout}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	startTime := time.Now()
+	for {
+		node, err := c.GetNode(ctx, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		if node.File.Locked == nil {
+			return node, nil
+		}
+		if node.File.Locked.Error != "" {
+			return nil, fmt.Errorf("file lock error on node %s: %s", nodeID, node.File.Locked.Error)
+		}
+		if time.Since(startTime) > cfg.timeout {
+			return nil, fmt.Errorf("timeout waiting on file lock: node=%s", nodeID)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(cfg.interval):
+			// continue polling
+		}
+	}
+}
+
+// WaitIndex polls until a node's index is no longer locked.
+func (c *Client) WaitIndex(ctx context.Context, nodeID, indexName string, opts ...WaitOption) (*IdxInfo, error) {
+	if indexName == "" {
+		return nil, nil
+	}
+
+	cfg := waitConfig{interval: DefaultPollInterval, timeout: DefaultWaitTimeout}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	startTime := time.Now()
+	for {
+		node, err := c.GetNode(ctx, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		idx, has := node.Indexes[indexName]
+		if !has {
+			return nil, fmt.Errorf("index does not exist: node=%s, index=%s", nodeID, indexName)
+		}
+		if idx.Locked != nil && idx.Locked.Error != "" {
+			return nil, fmt.Errorf("index error: node=%s, index=%s, error=%s", nodeID, indexName, idx.Locked.Error)
+		}
+		if idx.Locked == nil {
+			return idx, nil
+		}
+		if time.Since(startTime) > cfg.timeout {
+			return nil, fmt.Errorf("timeout waiting on index lock: node=%s, index=%s", nodeID, indexName)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(cfg.interval):
+			// continue polling
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,6 +13,9 @@ github.com/Azure/azure-pipeline-go/pipeline
 # github.com/Azure/azure-storage-blob-go v0.8.0
 ## explicit
 github.com/Azure/azure-storage-blob-go/azblob
+# github.com/MG-RAST/Shock/clients/shock-go v0.0.0-00010101000000-000000000000 => ./clients/shock-go
+## explicit; go 1.22
+github.com/MG-RAST/Shock/clients/shock-go
 # github.com/MG-RAST/go-shock-client v0.0.0-20190828185941-363c96852f00
 ## explicit
 github.com/MG-RAST/go-shock-client
@@ -248,3 +251,4 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit; go 1.15
 gopkg.in/yaml.v3
+# github.com/MG-RAST/Shock/clients/shock-go => ./clients/shock-go


### PR DESCRIPTION
## Summary

- **New `clients/shock-go/` library**: A modern, zero-external-dependency Go client for the Shock API, replacing the vendored `go-shock-client` for CLI usage
- **Updated `shock-client/` CLI**: Migrated from old `go-shock-client` to the new library with identical behavior
- **Bug fixes**: Corrected JSON tags (`linkage`, `version_parts`), added missing `Node` fields (`Locations`, `Restore`), typed ACL/unpack responses, removed `log.Fatal` and `ioutil` usage

## Key changes

### New client library (`clients/shock-go/`)
| File | Purpose |
|------|---------|
| `types.go` | All exported types matching server JSON tags exactly |
| `client.go` | Client with functional options (`WithToken`, `WithAuthType`, `WithHTTPClient`, `WithDebug`) |
| `helpers.go` | Internal HTTP layer with streaming multipart uploads via `io.Pipe` |
| `node.go` + `upload.go` | Node CRUD with `CreateOption` functional options |
| `query.go` | Query/QueryFull/QueryDistinct with `QueryResult` type |
| `acl.go` | Typed `*DisplayAcl` responses (was `interface{}`) |
| `download.go` | Streaming downloads with gzip decompression and MD5 |
| `location.go` | New location management endpoints |
| `wait.go` | Context-aware polling with configurable timeout |
| `server.go`, `index.go`, `md5.go`, `unpack.go` | Remaining endpoints |

### Bug fixes vs old client
- `Linkages` JSON tag: `"linkages"` → `"linkage"` (matches server)
- `VersionParts`: `json:"-"` → `json:"version_parts"` (was excluded from responses)
- `GetAcl` returns `*DisplayAcl` instead of `interface{}`
- `UnpackArchiveNode` returns `[]Node` instead of `interface{}`
- No `log.Fatal` in library code (returns errors instead)
- `context.Context` on all methods
- No deprecated `ioutil` usage

### CLI migration
- `shock-client/shock-client.go`, `chunk.go`, `util.go` updated to use new imports
- All method calls now pass `context.Background()`
- Server continues using vendored old client (out of scope)

## Test plan

- [x] `cd clients/shock-go && go build ./...` — compiles with zero dependencies
- [x] `cd clients/shock-go && go vet ./...` — no issues
- [x] `go build -mod=vendor ./shock-client/` — CLI compiles against new library
- [x] No `go.sum` in `clients/shock-go/` (confirms zero external deps)
- [x] No `ioutil` imports in library or CLI
- [x] No `log.Fatal` calls in library code
- [ ] Integration test against running Shock server

🤖 Generated with [Claude Code](https://claude.com/claude-code)